### PR TITLE
Re-factor closure to enable compatibility with PHP 5.3

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/Plugin.php
+++ b/src/MagentoHackathon/Composer/Magento/Plugin.php
@@ -196,10 +196,11 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     public function onNewCodeEvent(CommandEvent $event)
     {
 
+        $packageTypeToMatch = static::PACKAGE_TYPE;
         $magentoModules = array_filter(
             $this->composer->getRepositoryManager()->getLocalRepository()->getPackages(),
-            function(PackageInterface $package) {
-                return $package->getType() === static::PACKAGE_TYPE;
+            function (PackageInterface $package) use ($packageTypeToMatch) {
+                return $package->getType() === $packageTypeToMatch;
             }
         );
 


### PR DESCRIPTION
This plugin does not work in PHP 5.3.

Closures (anonymous functions) are not bound to any scope in PHP 5.3. Therefore, you cannot use `static::` within a closure before PHP 5.4. Given that `composer.json` claims that this plugin works on PHP 5.3, this functionality needs to be re-factored.