### PR TITLE
Update Bootstrap file generation

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/Patcher/Bootstrap.php
+++ b/src/MagentoHackathon/Composer/Magento/Patcher/Bootstrap.php
@@ -39,7 +39,7 @@ class Bootstrap
         $mageFileContent = file($appPath . '/Mage.php');
 
         $mageClassFile = '';
-        $mageBootstrapFile = '';
+        $mageBootstrapFile = '<?php' . PHP_EOL;
         $isBootstrapPart = false;
         foreach ($mageFileContent as $row) {
             if (strpos($row, 'define') === 0) {
@@ -76,8 +76,8 @@ php;
         $bootstrapFile
             = <<<php
 <?php
-require __DIR__ . 'Mage.bootstrap.php';
-require __DIR__ . 'Mage.class.php';
+require __DIR__ . '/Mage.class.php';
+require __DIR__ . '/Mage.bootstrap.php';
 
 php;
         if (!file_exists($appPath . '/bootstrap.php')) {

--- a/tests/MagentoHackathon/Composer/Magento/Patcher/BootstrapTest.php
+++ b/tests/MagentoHackathon/Composer/Magento/Patcher/BootstrapTest.php
@@ -16,7 +16,7 @@ class BootstrapTest extends \PHPUnit_Framework_TestCase
      *
      * @param $MageFile
      */
-    public function testMageFiles($MageFile)
+    public function testMageFilesExist($MageFile)
     {
 
         $structure = array(
@@ -37,6 +37,28 @@ class BootstrapTest extends \PHPUnit_Framework_TestCase
         $this->assertFileExists(vfsStream::url('patcherMagentoBase/app/Mage.class.php'));
         $this->assertFileExists(vfsStream::url('patcherMagentoBase/app/Mage.bootstrap.php'));
         $this->assertFileNotExists(vfsStream::url('patcherMagentoBase/app/Mage.nonsense.php'));
+    }
+
+    /**
+     * @dataProvider mageFileProvider
+     *
+     * Ensure that the Mage class is valid PHP
+     * @param  string $MageFile
+     * @return void
+     */
+    public function testMageClassFile($MageFile)
+    {
+        $structure = array(
+            'app' => array(
+                'Mage.php' => file_get_contents($MageFile),
+            ),
+        );
+        $directory = vfsStream::setup('patcherMagentoBase', null, $structure);
+        $patcher = new Bootstrap(vfsStream::url('patcherMagentoBase'));
+        $patcher->patch();
+
+        require vfsStream::url('patcherMagentoBase/app/Mage.class.php');
+        $this->assertTrue(class_exists('Mage'));
     }
 
     public function mageFileProvider()


### PR DESCRIPTION
Some fixes:
 - Start bootstrap file with `<?php`
 - Switch order of bootstrap's includes
  - Otherwise, Mage.bootstrap.php tries to use `Mage` before Mage exists
 - Add DS between `__DIR__` and file names

Also expanded testing a bit
 - Ensure that the Mage class file is working
 - Other files should be tested (parsed?) but how?