### PR TITLE
Resolve composer executable name + some refactoring

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,17 +20,9 @@
         </testsuite>
     </testsuites>
 
-    <groups>
-        <exclude>
-            <group>slow</group>
-        </exclude>
-    </groups>
-
     <filter>
         <whitelist>
             <directory>./src/</directory>
-            <exclude>
-            </exclude>
         </whitelist>
     </filter>
 </phpunit>

--- a/tests/MagentoHackathon/Composer/FullStack/FullStackTest.php
+++ b/tests/MagentoHackathon/Composer/FullStack/FullStackTest.php
@@ -7,17 +7,6 @@ use Symfony\Component\Process\Process;
 
 class FullStackTest extends FullStack\AbstractTest
 {
-    
-
-    protected function setUp()
-    {
-        
-    }
-    
-    protected function tearDown()
-    {
-        
-    }
 
     public static function setUpBeforeClass()
     {
@@ -33,30 +22,16 @@ class FullStackTest extends FullStack\AbstractTest
                     $file->getPathname()
                 );
                 $process->run();
-                if ($process->getExitCode() !== 0) {
-                    $message = sprintf(
-                        "process for <code>%s</code> exited with %s: %s%sError Message:%s%s%sOutput:%s%s",
-                        $process->getCommandLine(),
-                        $process->getExitCode(),
-                        $process->getExitCodeText(),
-                        PHP_EOL,
-                        PHP_EOL,
-                        $process->getErrorOutput(),
-                        PHP_EOL,
-                        PHP_EOL,
-                        $process->getOutput()
-                    );
-                    echo $message;
-                }
+                parent::printProcessMessageIfError($process);
             }
         }
     }
-    
+
     public static function tearDownAfterClass()
     {
         parent::tearDownAfterClass();
     }
-    
+
     protected function prepareCleanDirectories()
     {
         $fs = new Filesystem();
@@ -68,7 +43,7 @@ class FullStackTest extends FullStack\AbstractTest
         $fs->removeDirectory(self::getBasePath().'/magento-modules/vendor');
         $fs->remove(self::getBasePath().'/magento-modules/composer.lock');
     }
-    
+
     protected function installBaseMagento()
     {
         $process = new Process(
@@ -80,7 +55,7 @@ class FullStackTest extends FullStack\AbstractTest
         self::logProcessOutput($process, 'installBaseMagento');
         $this->assertProcess($process);
     }
-    
+
     protected function getMethodRunConfigs()
     {
         $array = array(
@@ -117,12 +92,12 @@ class FullStackTest extends FullStack\AbstractTest
                     'module_composer_json' => "composer_1_copy_force.json",
                 ),
             ),
-            
+
         );
-        
+
         return $array;
     }
-    
+
     public function methodProvider()
     {
         return array(
@@ -143,9 +118,9 @@ class FullStackTest extends FullStack\AbstractTest
         );
 
         $methods = $this->getMethodRunConfigs();
-        
+
         $runs = $methods[$method];
-            
+
             $this->prepareCleanDirectories();
 
             $this->installBaseMagento();
@@ -189,7 +164,7 @@ class FullStackTest extends FullStack\AbstractTest
             }
         }
     }
-    
+
     protected function changeModuleComposerFileAndUpdate($file, $command = "update")
     {
         $magentoModuleComposerFile = self::getBasePath().'/magento-modules/composer.json';
@@ -215,7 +190,7 @@ class FullStackTest extends FullStack\AbstractTest
         self::logProcessOutput($process);
         $this->assertProcess($process);
     }
-    
+
     protected function getFirstOnlyFileTestSet()
     {
         return array(


### PR DESCRIPTION
This does a couple of things:
- fixes `Output:
process for <code>composer.phar archive --format=zip --dir="../../../../tests/FullStackTest/artifact" -vvv</code> exited with 127: Command not found
Error Message:
sh: composer.phar: command not found`, for people who renamed their `composer.phar` to `composer` (like me)
- removed the *silent* exclusion of slow tests from `phpunit.xml.dist`, because it should be left to the devs decision (explicit exclusion)
- some common logic extracted into methods
- phpstorm automagically and conveniently removed all trailing whitespaces (so better use the `?w=1` trick to view this on github)