### PR TITLE
Create a new "extra" option flag to control patching of Mage.php (patching applied by default)

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/Patcher/Bootstrap.php
+++ b/src/MagentoHackathon/Composer/Magento/Patcher/Bootstrap.php
@@ -1,32 +1,54 @@
 <?php
-/**
- *
- *
- *
- *
- */
 
 namespace MagentoHackathon\Composer\Magento\Patcher;
 
+use MagentoHackathon\Composer\Magento\ProjectConfig;
+
 class Bootstrap
 {
-    protected $magentoBasePath;
+    /**
+     * @var ProjectConfig
+     */
+    private $config;
 
-    public function __construct($magentoBasePath)
+    public function __construct(ProjectConfig $config)
     {
-        $this->magentoBasePath = $magentoBasePath;
+        $this->config = $config;
     }
 
+    /**
+     * @return ProjectConfig
+     */
+    private function getConfig()
+    {
+        return $this->config;
+    }
 
+    private function canApplyPatch()
+    {
+        $mageClassPath = $this->getConfig()->getMagentoRootDir() . '/app/Mage.php';
+
+        return $this->getConfig()->mustApplyBootloaderPatch() &&
+               is_file($mageClassPath) &&
+               is_writable($mageClassPath);
+    }
+
+    /**
+     * @return bool
+     */
     public function patch()
     {
-        $this->splitOriginalMage();
-        $this->generateBootstrapFile();
+        if ($this->canApplyPatch()) {
+            $this->splitOriginalMage();
+            $this->generateBootstrapFile();
+            return true;
+        }
+        return false;
     }
 
     protected function getAppPath()
     {
-        return $this->magentoBasePath . '/app';
+        return $this->getConfig()->getMagentoRootDir() . '/app';
     }
 
     protected function splitOriginalMage()

--- a/src/MagentoHackathon/Composer/Magento/Patcher/Bootstrap.php
+++ b/src/MagentoHackathon/Composer/Magento/Patcher/Bootstrap.php
@@ -28,7 +28,7 @@ class Bootstrap
     {
         $mageClassPath = $this->getConfig()->getMagentoRootDir() . '/app/Mage.php';
 
-        return $this->getConfig()->mustApplyBootloaderPatch() &&
+        return $this->getConfig()->mustApplyBootstrapPatch() &&
                is_file($mageClassPath) &&
                is_writable($mageClassPath);
     }

--- a/src/MagentoHackathon/Composer/Magento/Plugin.php
+++ b/src/MagentoHackathon/Composer/Magento/Plugin.php
@@ -41,7 +41,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
      * The type of packages this plugin supports
      */
     const PACKAGE_TYPE = 'magento-module';
-    
+
     const VENDOR_DIR_KEY = 'vendor-dir';
 
     const BIN_DIR_KEY = 'bin-dir';
@@ -93,7 +93,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
 
         $this->applyEvents($eventManager);
     }
-    
+
     protected function applyEvents(EventManager $eventManager)
     {
 
@@ -141,7 +141,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         $this->config = new ProjectConfig($composer->getPackage()->getExtra(), $composer->getConfig()->all());
 
         $this->veryfiyComposerRepositories();
-        
+
         $this->entryFactory = new EntryFactory(
             $this->config,
             new DeploystrategyFactory($this->config),
@@ -236,11 +236,8 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         $moduleManager->updateInstalledPackages($magentoModules);
         $this->deployLibraries();
 
-        if (file_exists($this->config->getMagentoRootDir() . '/app/Mage.php')) {
-            $patcher = new Bootstrap($this->config->getMagentoRootDir());
-            $patcher->patch();
-        }
-        
+        $patcher = new Bootstrap($this->config);
+        $patcher->patch();
     }
 
     /**
@@ -272,7 +269,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             $this->io->write(sprintf($message1, 'packages.magento.com'));
             $this->io->write(sprintf($message2, 'magento', 'https?://packages.magento.com'));
         }
-        
+
     }
 
     /**

--- a/src/MagentoHackathon/Composer/Magento/ProjectConfig.php
+++ b/src/MagentoHackathon/Composer/Magento/ProjectConfig.php
@@ -445,6 +445,6 @@ class ProjectConfig
      */
     public function mustApplyBootstrapPatch()
     {
-        return (bool) $this->fetchVarFromExtraConfig(self::EXTRA_WITH_BOOTSTRAP_PATCH_KEY, false);
+        return (bool) $this->fetchVarFromExtraConfig(self::EXTRA_WITH_BOOTSTRAP_PATCH_KEY, true);
     }
 }

--- a/src/MagentoHackathon/Composer/Magento/ProjectConfig.php
+++ b/src/MagentoHackathon/Composer/Magento/ProjectConfig.php
@@ -443,7 +443,7 @@ class ProjectConfig
     /**
      * @return boolean
      */
-    public function mustApplyBootloaderPatch()
+    public function mustApplyBootstrapPatch()
     {
         return (bool) $this->fetchVarFromExtraConfig(self::EXTRA_WITH_BOOTSTRAP_PATCH_KEY, false);
     }

--- a/src/MagentoHackathon/Composer/Magento/ProjectConfig.php
+++ b/src/MagentoHackathon/Composer/Magento/ProjectConfig.php
@@ -38,6 +38,8 @@ class ProjectConfig
     // Default Values
     const DEFAULT_MAGENTO_ROOT_DIR = 'root';
 
+    const EXTRA_WITH_BOOTSTRAP_PATCH_KEY = 'with-bootstrap-patch';
+
     protected $libraryPath;
     protected $libraryPackages;
     protected $extra;
@@ -58,11 +60,11 @@ class ProjectConfig
     }
 
     /**
-     * @param      $array
-     * @param      $key
-     * @param null $default
+     * @param array $array
+     * @param string|integer $key
+     * @param mixed $default
      *
-     * @return null
+     * @return mixed
      */
     protected function fetchVarFromConfigArray($array, $key, $default = null)
     {
@@ -144,7 +146,7 @@ class ProjectConfig
     {
         return $this->hasExtraField(self::MAGENTO_ROOT_DIR_KEY);
     }
-    
+
     public function getMagentoVarDir()
     {
         return $this->getMagentoRootDir().'var'.DIRECTORY_SEPARATOR;
@@ -291,7 +293,7 @@ class ProjectConfig
     {
         return $this->hasExtraField(self::MAGENTO_FORCE_KEY);
     }
-    
+
     public function getMagentoForceByPackageName($packagename)
     {
         return $this->getMagentoForce();
@@ -422,7 +424,7 @@ class ProjectConfig
     {
         return array_change_key_case($array, CASE_LOWER);
     }
-    
+
     public function getComposerRepositories()
     {
         return $this->fetchVarFromConfigArray($this->composerConfig, 'repositories', array());
@@ -436,5 +438,13 @@ class ProjectConfig
     public function getVendorDir()
     {
         return $this->fetchVarFromConfigArray($this->composerConfig, 'vendor-dir', 'vendor');
+    }
+
+    /**
+     * @return boolean
+     */
+    public function mustApplyBootloaderPatch()
+    {
+        return (bool) $this->fetchVarFromExtraConfig(self::EXTRA_WITH_BOOTSTRAP_PATCH_KEY, false);
     }
 }

--- a/tests/MagentoHackathon/Composer/Magento/Patcher/BootstrapTest.php
+++ b/tests/MagentoHackathon/Composer/Magento/Patcher/BootstrapTest.php
@@ -2,34 +2,39 @@
 
 namespace MagentoHackathon\Composer\Magento\Patcher;
 
+use MagentoHackathon\Composer\Magento\ProjectConfig;
 use org\bovigo\vfs\vfsStream;
 
-/**
- *
- */
 class BootstrapTest extends \PHPUnit_Framework_TestCase
 {
 
     /**
-     *
      * @dataProvider mageFileProvider
-     *
-     * @param $MageFile
+     * @param $mageFile
      */
-    public function testMageFilesExist($MageFile)
+    public function testMageFilesExist($mageFile)
     {
-
         $structure = array(
             'app' => array(
-                'Mage.php' => file_get_contents($MageFile),
+                'Mage.php' => file_get_contents($mageFile),
             ),
         );
-        $directory = vfsStream::setup('patcherMagentoBase', null, $structure);
-        $patcher = new Bootstrap(vfsStream::url('patcherMagentoBase'));
+        vfsStream::setup('patcherMagentoBase', null, $structure);
+
+        $config = new ProjectConfig(
+            array(
+                ProjectConfig::EXTRA_WITH_BOOTSTRAP_PATCH_KEY => true,
+                ProjectConfig::MAGENTO_ROOT_DIR_KEY => vfsStream::url('patcherMagentoBase'),
+            ),
+            array()
+        );
+
+        $patcher = new Bootstrap($config);
         $patcher->patch();
+
         $this->assertFileExists(vfsStream::url('patcherMagentoBase/app/Mage.php'));
         $this->assertFileNotEquals(
-            $MageFile,
+            $mageFile,
             vfsStream::url('patcherMagentoBase/app/Mage.php'),
             'File should be modified but its not'
         );
@@ -40,25 +45,100 @@ class BootstrapTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider mageFileProvider
-     *
      * Ensure that the Mage class is valid PHP
-     * @param  string $MageFile
+     *
+     * @dataProvider mageFileProvider
+     * @param string $mageFile
      * @return void
      */
-    public function testMageClassFile($MageFile)
+    public function testMageClassFile($mageFile)
     {
         $structure = array(
             'app' => array(
-                'Mage.php' => file_get_contents($MageFile),
+                'Mage.php' => file_get_contents($mageFile),
             ),
         );
-        $directory = vfsStream::setup('patcherMagentoBase', null, $structure);
-        $patcher = new Bootstrap(vfsStream::url('patcherMagentoBase'));
+        vfsStream::setup('patcherMagentoBase', null, $structure);
+
+        $config = new ProjectConfig(
+            array(
+                ProjectConfig::EXTRA_WITH_BOOTSTRAP_PATCH_KEY => true,
+                ProjectConfig::MAGENTO_ROOT_DIR_KEY => vfsStream::url('patcherMagentoBase'),
+            ),
+            array()
+        );
+
+        $patcher = new Bootstrap($config);
         $patcher->patch();
 
         require vfsStream::url('patcherMagentoBase/app/Mage.class.php');
         $this->assertTrue(class_exists('Mage'));
+    }
+
+    /**
+     * @dataProvider mageFileProvider
+     */
+    public function testMageFileIsNotModifiedWhenThePatchingFeatureIsOff($mageFile)
+    {
+        $structure = array(
+            'app' => array(
+                'Mage.php' => file_get_contents($mageFile),
+            ),
+        );
+        vfsStream::setup('root', null, $structure);
+
+        $config = new ProjectConfig(
+            array(
+                ProjectConfig::EXTRA_WITH_BOOTSTRAP_PATCH_KEY => false,
+                ProjectConfig::MAGENTO_ROOT_DIR_KEY => vfsStream::url('root'),
+            ),
+            array()
+        );
+
+        $patcher = new Bootstrap($config);
+        $patcher->patch();
+
+        $this->assertBootstrapWasNotApplied($mageFile);
+    }
+
+    /**
+     * @dataProvider mageFileProvider
+     */
+    public function testBootstrapPatchIsNotAppliedByDefault($mageFile)
+    {
+        $structure = array(
+            'app' => array(
+                'Mage.php' => file_get_contents($mageFile),
+            ),
+        );
+        vfsStream::setup('root', null, $structure);
+
+        $config = new ProjectConfig(
+            // the patch flag is not declared on purpose
+            array(
+                ProjectConfig::MAGENTO_ROOT_DIR_KEY => vfsStream::url('root'),
+            ),
+            array()
+        );
+
+        $patcher = new Bootstrap($config);
+        $patcher->patch();
+
+        $this->assertBootstrapWasNotApplied($mageFile);
+    }
+
+    private function assertBootstrapWasNotApplied($mageFile)
+    {
+        $this->assertFileExists(vfsStream::url('root/app/Mage.php'));
+        $this->assertFileEquals(
+            $mageFile,
+            vfsStream::url('root/app/Mage.php'),
+            'File should not be modified but it is'
+        );
+        $this->assertFileNotExists(vfsStream::url('root/app/bootstrap.php'));
+        $this->assertFileNotExists(vfsStream::url('root/app/Mage.class.php'));
+        $this->assertFileNotExists(vfsStream::url('root/app/Mage.bootstrap.php'));
+        $this->assertFileNotExists(vfsStream::url('root/app/Mage.nonsense.php'));
     }
 
     public function mageFileProvider()

--- a/tests/MagentoHackathon/Composer/Magento/Patcher/BootstrapTest.php
+++ b/tests/MagentoHackathon/Composer/Magento/Patcher/BootstrapTest.php
@@ -19,12 +19,12 @@ class BootstrapTest extends \PHPUnit_Framework_TestCase
                 'Mage.php' => file_get_contents($mageFile),
             ),
         );
-        vfsStream::setup('patcherMagentoBase', null, $structure);
+        vfsStream::setup('root', null, $structure);
 
         $config = new ProjectConfig(
             array(
                 ProjectConfig::EXTRA_WITH_BOOTSTRAP_PATCH_KEY => true,
-                ProjectConfig::MAGENTO_ROOT_DIR_KEY => vfsStream::url('patcherMagentoBase'),
+                ProjectConfig::MAGENTO_ROOT_DIR_KEY => vfsStream::url('root'),
             ),
             array()
         );
@@ -32,16 +32,7 @@ class BootstrapTest extends \PHPUnit_Framework_TestCase
         $patcher = new Bootstrap($config);
         $patcher->patch();
 
-        $this->assertFileExists(vfsStream::url('patcherMagentoBase/app/Mage.php'));
-        $this->assertFileNotEquals(
-            $mageFile,
-            vfsStream::url('patcherMagentoBase/app/Mage.php'),
-            'File should be modified but its not'
-        );
-        $this->assertFileExists(vfsStream::url('patcherMagentoBase/app/bootstrap.php'));
-        $this->assertFileExists(vfsStream::url('patcherMagentoBase/app/Mage.class.php'));
-        $this->assertFileExists(vfsStream::url('patcherMagentoBase/app/Mage.bootstrap.php'));
-        $this->assertFileNotExists(vfsStream::url('patcherMagentoBase/app/Mage.nonsense.php'));
+        $this->assertBootstrapWasApplied($mageFile);
     }
 
     /**
@@ -58,12 +49,12 @@ class BootstrapTest extends \PHPUnit_Framework_TestCase
                 'Mage.php' => file_get_contents($mageFile),
             ),
         );
-        vfsStream::setup('patcherMagentoBase', null, $structure);
+        vfsStream::setup('root', null, $structure);
 
         $config = new ProjectConfig(
             array(
                 ProjectConfig::EXTRA_WITH_BOOTSTRAP_PATCH_KEY => true,
-                ProjectConfig::MAGENTO_ROOT_DIR_KEY => vfsStream::url('patcherMagentoBase'),
+                ProjectConfig::MAGENTO_ROOT_DIR_KEY => vfsStream::url('root'),
             ),
             array()
         );
@@ -71,7 +62,7 @@ class BootstrapTest extends \PHPUnit_Framework_TestCase
         $patcher = new Bootstrap($config);
         $patcher->patch();
 
-        require vfsStream::url('patcherMagentoBase/app/Mage.class.php');
+        require vfsStream::url('root/app/Mage.class.php');
         $this->assertTrue(class_exists('Mage'));
     }
 
@@ -104,7 +95,7 @@ class BootstrapTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider mageFileProvider
      */
-    public function testBootstrapPatchIsNotAppliedByDefault($mageFile)
+    public function testBootstrapPatchIsAppliedByDefault($mageFile)
     {
         $structure = array(
             'app' => array(
@@ -124,7 +115,7 @@ class BootstrapTest extends \PHPUnit_Framework_TestCase
         $patcher = new Bootstrap($config);
         $patcher->patch();
 
-        $this->assertBootstrapWasNotApplied($mageFile);
+        $this->assertBootstrapWasApplied($mageFile);
     }
 
     private function assertBootstrapWasNotApplied($mageFile)
@@ -138,6 +129,20 @@ class BootstrapTest extends \PHPUnit_Framework_TestCase
         $this->assertFileNotExists(vfsStream::url('root/app/bootstrap.php'));
         $this->assertFileNotExists(vfsStream::url('root/app/Mage.class.php'));
         $this->assertFileNotExists(vfsStream::url('root/app/Mage.bootstrap.php'));
+        $this->assertFileNotExists(vfsStream::url('root/app/Mage.nonsense.php'));
+    }
+
+    private function assertBootstrapWasApplied($mageFile)
+    {
+        $this->assertFileExists(vfsStream::url('root/app/Mage.php'));
+        $this->assertFileNotEquals(
+            $mageFile,
+            vfsStream::url('root/app/Mage.php'),
+            'File should be modified but its not'
+        );
+        $this->assertFileExists(vfsStream::url('root/app/bootstrap.php'));
+        $this->assertFileExists(vfsStream::url('root/app/Mage.class.php'));
+        $this->assertFileExists(vfsStream::url('root/app/Mage.bootstrap.php'));
         $this->assertFileNotExists(vfsStream::url('root/app/Mage.nonsense.php'));
     }
 


### PR DESCRIPTION
This PR adds the new _boolean_  `extra` param - `with-bootstrap-patch` -, which can control if the `Mage.php` is changed/patched. 

If this param isn't found in `extra`, it'll be assumed `false` - hence no patching by default.