### PR TITLE
Fixes wrong value returned when getting the vendor dir through PluginConfig

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/ProjectConfig.php
+++ b/src/MagentoHackathon/Composer/Magento/ProjectConfig.php
@@ -437,7 +437,11 @@ class ProjectConfig
      */
     public function getVendorDir()
     {
-        return $this->fetchVarFromConfigArray($this->composerConfig, 'vendor-dir', 'vendor');
+        return $this->fetchVarFromConfigArray(
+            $this->composerConfig['config'],
+            'vendor-dir',
+            getcwd() . '/vendor'
+        );
     }
 
     /**

--- a/tests/MagentoHackathon/Composer/Magento/ModuleManagerTest.php
+++ b/tests/MagentoHackathon/Composer/Magento/ModuleManagerTest.php
@@ -30,7 +30,7 @@ class ModuleManagerTest extends \PHPUnit_Framework_TestCase
             new InstalledPackageDumper()
         );
 
-        $config = new ProjectConfig(array(), array('vendor-dir' => 'vendor'));
+        $config = new ProjectConfig(array(), array('config' => array('vendor-dir' => 'vendor')));
         $this->unInstallStrategy =
             $this->getMock('MagentoHackathon\Composer\Magento\UnInstallStrategy\UnInstallStrategyInterface');
 


### PR DESCRIPTION
When using `\MagentoHackathon\Composer\Magento\ProjectConfig::getVendorDir()`, the passed array didn't contain the `vendor-dir` key (a sub-array of it did), so the default value was always returned (i.e. "vendor"), irrelevant of the configuration in "composer.json".

Also, the said method must always return the absolute path to the vendor folder, as it's the case with Composer.

----
Instantiation of the PluginConfig class is somewhat inconsistent:
```php
// \MagentoHackathon\Composer\Magento\Plugin::activate
$this->config = new ProjectConfig($composer->getPackage()->getExtra(), $composer->getConfig()->all());
```
or
```php
// \MagentoHackathon\Composer\Helper::__construct
        $reader = new \Eloquent\Composer\Configuration\ConfigurationReader;
        $composerJsonObject = $reader->read($this->projectRoot.'/composer.json');
        $this->magentoProjectConfig = new ProjectConfig(
            (array)$composerJsonObject->extra(),
            (array)$composerJsonObject
        );
```
`$composer->getConfig()->all()` is quite different from `(array)$composerJsonObject` because the former is dynamic: https://github.com/composer/composer/blob/master/src/Composer/Config.php#L264. The latter's just a fancy json_decode.   
Case in point with this PR: Composer gets the _absolute_ path to the vendor dir _by defaut_, whereas using the Eloquent does not: https://github.com/composer/composer/blob/master/src/Composer/Config.php#L181. And the default fallback implemented in `\MagentoHackathon\Composer\Magento\ProjectConfig::fetchVarFromConfigArray()` also suffers from this, as the default values _we_ provide could be different than Composer's.

As for testing (I'm guessing that's why you used Eloquent's json wrapper), I haven't researched, but I'm pretty sure you can use Composer's Config with various `composer.json` fixtures.

And seeing how the instantiation of ProjectConfig is very specific, I think it's better that **it** should do the work, instead of the caller. Like a named constructor (making the `__construct` private also):
```php
    /**
     * @param Composer $composer
     * @return ProjectConfig
     */
    public static function fromComposer(Composer $composer)
    {
        return new self(
            $composer->getPackage()->getExtra(),
            $composer->getConfig()->all()
        );
    }
```