### PR TITLE
Check if vendor key exists, before usage

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/ProjectConfig.php
+++ b/src/MagentoHackathon/Composer/Magento/ProjectConfig.php
@@ -438,7 +438,7 @@ class ProjectConfig
     public function getVendorDir()
     {
         return $this->fetchVarFromConfigArray(
-            $this->composerConfig['config'],
+            isset($this->composerConfig['config']) ? $this->composerConfig['config'] : array(),
             'vendor-dir',
             getcwd() . '/vendor'
         );


### PR DESCRIPTION
Explodes on badly written unit tests.