### PR TITLE
Alternate patch to #34 for fixing #7 and #33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
-- 
-
+- Reverted PR [#34](https://github.com/Cotya/magento-composer-installer/pull/34) in favor of a simpler solution without breaking BC
+- Fixed issue [#7](https://github.com/Cotya/magento-composer-installer/issues/7) by filtering out Aliased Packages. This was with branch-aliasing where composer gave us two packages for the same module when it was setup to use branch aliasing
+- Fixed issue [#33](https://github.com/Cotya/magento-composer-installer/issues/33) by using the source reference from the composer package as part of the internal version number for tracking packages
 
 ## [3.0.4-beta1] - 2015-06-10
 - Fixed error when redeploying with no modules, using PHP 5.3.

--- a/composer.json
+++ b/composer.json
@@ -36,10 +36,6 @@
         {
             "name":"Vinai Kopp",
             "email":"vinai@netzarbeiter.com"
-        },
-        {
-            "name":"Dan Stefan Oprean",
-            "email":"dan@designxenon.com"
         }
     ],
     "require":{

--- a/src/MagentoHackathon/Composer/Magento/InstalledPackage.php
+++ b/src/MagentoHackathon/Composer/Magento/InstalledPackage.php
@@ -20,11 +20,6 @@ class InstalledPackage
     protected $version;
 
     /**
-     * @var string
-     */
-    protected $sourceReference;
-
-    /**
      * @var array
      */
     protected $installedFiles;
@@ -33,14 +28,12 @@ class InstalledPackage
      * @param string $name
      * @param string $version
      * @param array $files
-     * @param string $reference
      */
-    public function __construct($name, $version, array $files, $reference = null)
+    public function __construct($name, $version, array $files)
     {
         $this->name = $name;
         $this->installedFiles = $files;
         $this->version = $version;
-        $this->sourceReference = $reference;
     }
 
     /**
@@ -57,14 +50,6 @@ class InstalledPackage
     public function getVersion()
     {
         return $this->version;
-    }
-
-    /**
-     * @return string
-     */
-    public function getSourceReference()
-    {
-        return $this->sourceReference;
     }
 
     /**

--- a/src/MagentoHackathon/Composer/Magento/InstalledPackageDumper.php
+++ b/src/MagentoHackathon/Composer/Magento/InstalledPackageDumper.php
@@ -15,10 +15,9 @@ class InstalledPackageDumper
     public function dump(InstalledPackage $installedPackage)
     {
         return array(
-            'packageName' => $installedPackage->getName(),
-            'version' => $installedPackage->getVersion(),
-            'installedFiles' => $installedPackage->getInstalledFiles(),
-            'sourceReference' => $installedPackage->getSourceReference(),
+            'packageName'       => $installedPackage->getName(),
+            'version'           => $installedPackage->getVersion(),
+            'installedFiles'    => $installedPackage->getInstalledFiles(),
         );
     }
 
@@ -28,12 +27,6 @@ class InstalledPackageDumper
      */
     public function restore(array $data)
     {
-        $data['sourceReference'] = isset($data['sourceReference']) ? $data['sourceReference'] : null;
-        return new InstalledPackage(
-            $data['packageName'],
-            $data['version'],
-            $data['installedFiles'],
-            $data['sourceReference']
-        );
+        return new InstalledPackage($data['packageName'], $data['version'], $data['installedFiles']);
     }
 }

--- a/src/MagentoHackathon/Composer/Magento/Repository/InstalledPackageFileSystemRepository.php
+++ b/src/MagentoHackathon/Composer/Magento/Repository/InstalledPackageFileSystemRepository.php
@@ -114,30 +114,6 @@ class InstalledPackageFileSystemRepository implements InstalledPackageRepository
     }
 
     /**
-     * If source reference specified, perform a strict check,
-     * which only returns true if repository has the package in the specified source reference
-     *
-     * @param string $packageName
-     * @param string $reference
-     * @return bool
-     */
-    public function hasReference($packageName, $reference = null)
-    {
-        $this->load();
-        try {
-            $package = $this->findByPackageName($packageName);
-
-            if (null === $reference) {
-                return true;
-            }
-
-            return $package->getSourceReference() === $reference;
-        } catch (\Exception $e) {
-            return false;
-        }
-    }
-
-    /**
      * @param InstalledPackage $package
      * @throws \Exception
      */
@@ -145,20 +121,15 @@ class InstalledPackageFileSystemRepository implements InstalledPackageRepository
     {
         $this->load();
 
-        $this->hasChanges = true;
-
         try {
             $this->findByPackageName($package->getName());
-            foreach ($this->packages as &$installedPackage) {
-                if ($installedPackage->getName() === $package->getName()) {
-                    $installedPackage = $package;
-                }
-            }
         } catch (\Exception $e) {
             $this->packages[] = $package;
+            $this->hasChanges = true;
             return;
         }
 
+        throw new \Exception(sprintf('Package: "%s" is already installed', $package->getName()));
     }
 
     /**

--- a/src/MagentoHackathon/Composer/Magento/Repository/InstalledPackageRepositoryInterface.php
+++ b/src/MagentoHackathon/Composer/Magento/Repository/InstalledPackageRepositoryInterface.php
@@ -40,12 +40,4 @@ interface InstalledPackageRepositoryInterface
      * @return bool
      */
     public function has($packageName, $version = null);
-
-    /**
-     * @param string $packageName
-     * @param string $reference
-     * @return bool
-     */
-
-    public function hasReference($packageName, $reference = null);
 }

--- a/tests/MagentoHackathon/Composer/Magento/PluginTest.php
+++ b/tests/MagentoHackathon/Composer/Magento/PluginTest.php
@@ -5,8 +5,14 @@ namespace MagentoHackathon\Composer\Magento;
 use Composer\Composer;
 use Composer\Config;
 use Composer\Installer\InstallationManager;
+use Composer\Package\AliasPackage;
+use Composer\Package\Package;
 use Composer\Package\RootPackage;
+use Composer\Plugin\CommandEvent;
+use Composer\Repository\RepositoryManager;
+use Composer\Repository\WritableArrayRepository;
 use org\bovigo\vfs\vfsStream;
+use ReflectionObject;
 
 /**
  * Class PluginTest
@@ -22,6 +28,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase
     protected $root;
     protected $magentoDir;
     protected $plugin;
+    protected $eventManager;
 
     public function setUp()
     {
@@ -56,26 +63,29 @@ class PluginTest extends \PHPUnit_Framework_TestCase
         $this->io = $this->getMock('Composer\IO\IOInterface');
 
         $this->plugin = $this->getMockBuilder('MagentoHackathon\Composer\Magento\Plugin')
-            ->setMethods(array('getEventManager'))
+            ->setMethods(array('getEventManager', 'getModuleManager'))
             ->getMock();
+
+        $repoManager    = new RepositoryManager($this->io, $this->config);
+        $repoManager->setLocalRepository(new WritableArrayRepository);
+        $this->composer->setRepositoryManager($repoManager);
+
+        $this->eventManager = $this->getMock('MagentoHackathon\Composer\Magento\Event\EventManager');
+        $this->plugin
+            ->expects($this->any())
+            ->method('getEventManager')
+            ->will($this->returnValue($this->eventManager));
     }
 
     public function testInitDeployManagerRegistersGitIgnoreListenerIfConfigPermits()
     {
-        $eventManager = $this->getMock('MagentoHackathon\Composer\Magento\Event\EventManager');
-
-        $this->plugin
-            ->expects($this->once())
-            ->method('getEventManager')
-            ->will($this->returnValue($eventManager));
-
         $rootPackage = $this->createRootPackage(array(
             ProjectConfig::AUTO_APPEND_GITIGNORE_KEY => true
         ));
 
         $this->composer->setPackage($rootPackage);
 
-        $eventManager
+        $this->eventManager
             ->expects($this->once())
             ->method('listen')
             ->with('post-package-deploy', $this->isInstanceOf('MagentoHackathon\Composer\Magento\GitIgnoreListener'));
@@ -85,13 +95,6 @@ class PluginTest extends \PHPUnit_Framework_TestCase
 
     public function testDebugListenerIsAttached()
     {
-        $eventManager = $this->getMock('MagentoHackathon\Composer\Magento\Event\EventManager');
-
-        $this->plugin
-            ->expects($this->once())
-            ->method('getEventManager')
-            ->will($this->returnValue($eventManager));
-
         $this->io
             ->expects($this->any())
             ->method('isDebug')
@@ -99,12 +102,71 @@ class PluginTest extends \PHPUnit_Framework_TestCase
 
         $this->composer->setPackage($this->createRootPackage());
 
-        $eventManager
+        $this->eventManager
             ->expects($this->once())
             ->method('listen')
             ->with('pre-package-deploy', $this->isInstanceOf('Closure'));
 
         $this->plugin->activate($this->composer, $this->io);
+    }
+
+    public function testOnlyMagentoModulePackagesArePassedToModuleManager()
+    {
+        $this->composer->setPackage($this->createRootPackage());
+        $this->plugin->activate($this->composer, $this->io);
+        $moduleManagerMock = $this->getMockBuilder('\MagentoHackathon\Composer\Magento\ModuleManager')
+            ->disableOriginalConstructor()
+            ->setMethods(['updateInstalledPackages'])
+            ->getMock();
+
+        $this->plugin
+            ->expects($this->any())
+            ->method('getModuleManager')
+            ->will($this->returnValue($moduleManagerMock));
+
+        $mPackage1      = $this->createPackage('magento/module1', 'magento-module');
+        $mPackage2      = $this->createPackage('magento/module2', 'magento-module');
+        $normalPackage  = $this->createPackage('normal/module', 'other-module');
+        $lRepository    = $this->composer->getRepositoryManager()->getLocalRepository();
+        $lRepository->addPackage($mPackage1);
+        $lRepository->addPackage($mPackage2);
+        $lRepository->addPackage($normalPackage);
+
+        $moduleManagerMock
+            ->expects($this->once())
+            ->method('updateInstalledPackages')
+            ->with([$mPackage1, $mPackage2]);
+
+        $this->plugin->onNewCodeEvent(new \Composer\Script\Event('event', $this->composer, $this->io));
+    }
+
+    public function testAliasPackagesAreFilteredOut()
+    {
+        $this->composer->setPackage($this->createRootPackage());
+        $this->plugin->activate($this->composer, $this->io);
+        $moduleManagerMock = $this->getMockBuilder('\MagentoHackathon\Composer\Magento\ModuleManager')
+            ->disableOriginalConstructor()
+            ->setMethods(['updateInstalledPackages'])
+            ->getMock();
+
+        $this->plugin
+            ->expects($this->any())
+            ->method('getModuleManager')
+            ->will($this->returnValue($moduleManagerMock));
+
+        $mPackage   = $this->createPackage('magento/module1', 'magento-module');
+        $aPackage   = new AliasPackage($mPackage, '99999999-dev', '1.0.x-dev');
+
+        $lRepository    = $this->composer->getRepositoryManager()->getLocalRepository();
+        $lRepository->addPackage($mPackage);
+        $lRepository->addPackage($aPackage);
+
+        $moduleManagerMock
+            ->expects($this->once())
+            ->method('updateInstalledPackages')
+            ->with([$mPackage]);
+
+        $this->plugin->onNewCodeEvent(new \Composer\Script\Event('event', $this->composer, $this->io));
     }
 
     /**
@@ -116,6 +178,18 @@ class PluginTest extends \PHPUnit_Framework_TestCase
         $package = new RootPackage("root/package", "1.0.0", "root/package");
         $extra['magento-root-dir'] = vfsStream::url('root/htdocs');
         $package->setExtra($extra);
+        return $package;
+    }
+
+    /**
+     * @param string $name
+     * @param string $type
+     * @return Package
+     */
+    private function createPackage($name, $type)
+    {
+        $package = new Package($name, '1.0.0', $name);
+        $package->setType($type);
         return $package;
     }
 }

--- a/tests/MagentoHackathon/Composer/Magento/Repository/InstalledFilesFilesystemRepositoryTest.php
+++ b/tests/MagentoHackathon/Composer/Magento/Repository/InstalledFilesFilesystemRepositoryTest.php
@@ -82,6 +82,15 @@ class InstalledFilesFilesystemRepositoryTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('MagentoHackathon\Composer\Magento\InstalledPackage', $package);
     }
 
+    public function testExceptionIsThrownIfDuplicatePackageIsAdded()
+    {
+        $this->setExpectedException('Exception', 'Package: "some-package" is already installed');
+
+        $package = new InstalledPackage('some-package', '1.0.0', array());
+        $this->repository->add($package);
+        $this->repository->add($package);
+    }
+
     public function testAddInstalledMappings()
     {
         $files = array(
@@ -94,7 +103,6 @@ class InstalledFilesFilesystemRepositoryTest extends \PHPUnit_Framework_TestCase
             'packageName' => 'some-package',
             'version' => '1.0.0',
             'installedFiles' => $files,
-            'sourceReference' => null
         ));
         $package = new InstalledPackage('some-package', '1.0.0', $files);
         $this->repository->add($package);


### PR DESCRIPTION
I found the patch for #34 to be counter productive and it didn't really solve the issue of #7, more covered it up. 

This patch reverts #34 and provides a simpler patch.

## Issues:
#### #7
When we ask for the installed packages from Composer [here](https://github.com/Cotya/magento-composer-installer/blob/3.0.4-beta1/src/MagentoHackathon/Composer/Magento/Plugin.php#L201) we get duplicate packages for packages which use branch aliasing. We get one instance of `AliasPackage` and one instance of `CompletePackage`, but these packages have the same name and therefore `ModuleManager` processes them as if they are different packages. First it will install one, then attempt to install the other, then the exception will be thrown noting that the package has already been installed (it has).

#### #33
`dev-master` packages and the like (`dev-trunk`, etc) all return `9999999-dev` as their version number. `dev-develop` and `dev-feature-branch-x` will return themselves as they are.

If one of these packages is updated, we check to see if it exists in the `InstalledPackageFileSystemRepository` in the version that has just been currently updated to. It does, because the version installed was `dev-master` and the new version is `dev-master`. Even if the package has changed, e.g. new commits. The old package will not be removed and the new package will not be installed because there are seemingly no differences between the package versions. 

## Solutions
#### #7
Filter out instances of `AliasPackage`

#### #33 
Use a more robust method to track the version of installed packages. We can use `sourceReference` from the `CompletePackage`. This (in the case of `git`) will be a commit hash. This is different every time a packages changes, and is therefore a better method for tracking a package version. 

ping @nevvermind @Flyingmana @unknownnf

@unknownnf figured out how to better track versions so thanks for that. 

This patch is complete with unit tests

I've not squashed commits so you can see the revert and both of the fixes in separate commits. I can squash after if necessary. 