### PR TITLE
Optional suggest repo

### DIFF
--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -16,6 +16,16 @@ Which makes absolutely no sense for a module.
 
 currently No. As we need special configs this makes things a lot more complicated then installing on project level.
 
+### Can I disable repository suggestions?
+
+Yes, use the extra configuration option 'skip-suggest-repositories', like
+
+```json
+"extra": {
+    ...,
+    "skip-suggest-repositories": true
+}
+```
 
 ### I want to use the composer autoloader or some other different from magento one, how do I do this?
 

--- a/src/MagentoHackathon/Composer/Magento/Plugin.php
+++ b/src/MagentoHackathon/Composer/Magento/Plugin.php
@@ -149,7 +149,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         $this->filesystem = new Filesystem();
         $this->config = new ProjectConfig($composer->getPackage()->getExtra(), $composer->getConfig()->all());
 
-        $this->veryfiyComposerRepositories();
+        $this->suggestComposerRepositories();
 
         $this->entryFactory = new EntryFactory(
             $this->config,
@@ -241,7 +241,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     /**
      * test configured repositories and give message about adding recommended ones
      */
-    protected function veryfiyComposerRepositories()
+    protected function suggestComposerRepositories()
     {
         $foundFiregento = false;
         $foundMagento   = false;

--- a/src/MagentoHackathon/Composer/Magento/Plugin.php
+++ b/src/MagentoHackathon/Composer/Magento/Plugin.php
@@ -149,7 +149,9 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         $this->filesystem = new Filesystem();
         $this->config = new ProjectConfig($composer->getPackage()->getExtra(), $composer->getConfig()->all());
 
-        $this->suggestComposerRepositories();
+        if (!$this->config->skipSuggestComposerRepositories()) {
+            $this->suggestComposerRepositories();
+        }
 
         $this->entryFactory = new EntryFactory(
             $this->config,

--- a/src/MagentoHackathon/Composer/Magento/ProjectConfig.php
+++ b/src/MagentoHackathon/Composer/Magento/ProjectConfig.php
@@ -40,6 +40,8 @@ class ProjectConfig
 
     const EXTRA_WITH_BOOTSTRAP_PATCH_KEY = 'with-bootstrap-patch';
 
+    const EXTRA_WITH_SKIP_SUGGEST_KEY = 'skip-suggest-repositories';
+
     protected $libraryPath;
     protected $libraryPackages;
     protected $extra;
@@ -450,5 +452,13 @@ class ProjectConfig
     public function mustApplyBootstrapPatch()
     {
         return (bool) $this->fetchVarFromExtraConfig(self::EXTRA_WITH_BOOTSTRAP_PATCH_KEY, true);
+    }
+
+    /**
+     * @return boolean
+     */
+    public function skipSuggestComposerRepositories()
+    {
+        return (bool) $this->fetchVarFromExtraConfig(self::EXTRA_WITH_SKIP_SUGGEST_KEY, false);
     }
 }


### PR DESCRIPTION
The current version constantly suggests setting up repositories for packages.magento.com and packages.firegento.com. Packages.magento.com is only for Magento 2, so it's not always appropriate to suggest it. This pull request lets the user simply disable those suggestions via an extra config option.