### PR TITLE
Add documentation for package.xml mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
-
+- Added documentation for package.xml mapping (PR [#47](https://github.com/Cotya/magento-composer-installer/pull/47))
 
 ## [3.0.4] - 2015-07-12
 - Added PR [#40](https://github.com/Cotya/magento-composer-installer/pull/40): extra config option to skip repository suggestions

--- a/doc/Mapping.md
+++ b/doc/Mapping.md
@@ -20,24 +20,22 @@ The Magento root directory must be specified in the ```composer.json``` under ``
 
 **NOTE:** modman's include and bash feature will never get supported!
 
-
-
-### Mapping per JSON
+### Mapping with composer.json
 If you don't like modman files, you can define mappings in a package composer.json file instead.
 
 ```json
 {
    "name": "test/test",
    "type": "magento-module",
-    "extra": {
-        "map": [
-            ["themes/default/skin", "public/skin/frontend/foo/default"],
-            ["themes/default/design", "public/app/design/frontend/foo/default"],
-            ["modules/My_Module/My_Module.xml", "public/app/etc/modules/My_Module.xml"],
-            ["modules/My_Module/code", "public/app/code/local/My/Module"],
-            ["modules/My_Module/frontend/layout/mymodule.xml", "public/app/design/frontend/base/default/layout/mymodule.xml"]
-        ]
-    }
+   "extra": {
+      "map": [
+         ["themes/default/skin", "public/skin/frontend/foo/default"],
+         ["themes/default/design", "public/app/design/frontend/foo/default"],
+         ["modules/My_Module/My_Module.xml", "public/app/etc/modules/My_Module.xml"],
+         ["modules/My_Module/code", "public/app/code/local/My/Module"],
+         ["modules/My_Module/frontend/layout/mymodule.xml", "public/app/design/frontend/base/default/layout/mymodule.xml"]
+      ]
+   }
 }
 ```
 
@@ -47,24 +45,35 @@ So sample `module` is provided by `company` with version `*`.
 Here is the entry for composer.json:
 ```
 {
-    "require": {
-        ...
-        "company/module": "*"
-    },
-    "repositories": [
-        ...
-    ],
-    "extra": {
-        ...
-        "magento-map-overwrite": {
-            "company/module": [
-                ["app/code/community/CompanyDir/ModuleDir/*", "app/code/local/CompanyDir/ModuleDir"]
-            ]
-        }
-    }
+   "require": {
+      ...
+      "company/module": "*"
+   },
+   "repositories": [
+      ...
+   ],
+   "extra": {
+      ...
+      "magento-map-overwrite": {
+         "company/module": [
+            ["app/code/community/CompanyDir/ModuleDir/*", "app/code/local/CompanyDir/ModuleDir"]
+         ]
+      }
+   }
 }
-
 ```
+
 so `company/module` is an array of mapping entries - arrays where first key is source path and second key is destination path.
 
+### Mapping with package.xml
+If you wish to convert an existing Magento Connect repository with a minimum amount of effort, you use the existing package.xml. To enable that, simply specify `"extra": { "package-xml": "package.xml" }` in your composer.json. For example:
 
+```json
+{
+   "name": "test/test",
+   "type": "magento-module",
+   "extra": {
+		"package-xml": "package.xml"
+	}
+}
+```

--- a/doc/Mapping.md
+++ b/doc/Mapping.md
@@ -25,17 +25,17 @@ If you don't like modman files, you can define mappings in a package composer.js
 
 ```json
 {
-   "name": "test/test",
-   "type": "magento-module",
-   "extra": {
-      "map": [
-         ["themes/default/skin", "public/skin/frontend/foo/default"],
-         ["themes/default/design", "public/app/design/frontend/foo/default"],
-         ["modules/My_Module/My_Module.xml", "public/app/etc/modules/My_Module.xml"],
-         ["modules/My_Module/code", "public/app/code/local/My/Module"],
-         ["modules/My_Module/frontend/layout/mymodule.xml", "public/app/design/frontend/base/default/layout/mymodule.xml"]
-      ]
-   }
+    "name": "test/test",
+    "type": "magento-module",
+    "extra": {
+        "map": [
+            ["themes/default/skin", "public/skin/frontend/foo/default"],
+            ["themes/default/design", "public/app/design/frontend/foo/default"],
+            ["modules/My_Module/My_Module.xml", "public/app/etc/modules/My_Module.xml"],
+            ["modules/My_Module/code", "public/app/code/local/My/Module"],
+            ["modules/My_Module/frontend/layout/mymodule.xml", "public/app/design/frontend/base/default/layout/mymodule.xml"]
+        ]
+    }
 }
 ```
 
@@ -45,21 +45,21 @@ So sample `module` is provided by `company` with version `*`.
 Here is the entry for composer.json:
 ```
 {
-   "require": {
-      ...
-      "company/module": "*"
-   },
-   "repositories": [
-      ...
-   ],
-   "extra": {
-      ...
-      "magento-map-overwrite": {
-         "company/module": [
-            ["app/code/community/CompanyDir/ModuleDir/*", "app/code/local/CompanyDir/ModuleDir"]
-         ]
-      }
-   }
+    "require": {
+        ...
+        "company/module": "*"
+    },
+    "repositories": [
+        ...
+    ],
+    "extra": {
+        ...
+        "magento-map-overwrite": {
+            "company/module": [
+                ["app/code/community/CompanyDir/ModuleDir/*", "app/code/local/CompanyDir/ModuleDir"]
+            ]
+        }
+    }
 }
 ```
 
@@ -70,10 +70,10 @@ If you wish to convert an existing Magento Connect repository with a minimum amo
 
 ```json
 {
-   "name": "test/test",
-   "type": "magento-module",
-   "extra": {
-		"package-xml": "package.xml"
-	}
+    "name": "test/test",
+    "type": "magento-module",
+    "extra": {
+        "package-xml": "package.xml"
+    }
 }
 ```


### PR DESCRIPTION
There was no documentation about how to enable the `package.xml` mapping. While I was in there adding it I also fixed up some formatting issues.