### PR TITLE
Fix package XML mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
-
+- Fixed issue [#48](https://github.com/Cotya/magento-composer-installer/issues/48): Package XML mappings have './' prepended to them which breaks git-ignore functionality. Also explicitly adds a fw-slash to git-ignore paths, if one does not exist already.
 
 ## [3.0.4] - 2015-07-12
 - Added PR [#40](https://github.com/Cotya/magento-composer-installer/pull/40): extra config option to skip repository suggestions

--- a/src/MagentoHackathon/Composer/Magento/GitIgnore.php
+++ b/src/MagentoHackathon/Composer/Magento/GitIgnore.php
@@ -40,6 +40,7 @@ class GitIgnore
      */
     public function addEntry($file)
     {
+        $file = $this->prependSlashIfNotExist($file);
         if (!isset($this->lines[$file])) {
             $this->lines[$file] = $file;
         }
@@ -61,6 +62,7 @@ class GitIgnore
      */
     public function removeEntry($file)
     {
+        $file = $this->prependSlashIfNotExist($file);
         if (isset($this->lines[$file])) {
             unset($this->lines[$file]);
             $this->hasChanges = true;
@@ -93,5 +95,17 @@ class GitIgnore
         if ($this->hasChanges) {
             file_put_contents($this->gitIgnoreLocation, implode("\n", array_flip($this->lines)));
         }
+    }
+
+    /**
+     * Prepend a forward slash to a path
+     * if it does not already start with one.
+     *
+     * @param string $file
+     * @return string
+     */
+    private function prependSlashIfNotExist($file)
+    {
+        return sprintf('/%s', ltrim($file, '/'));
     }
 }

--- a/src/MagentoHackathon/Composer/Magento/Parser/PackageXmlParser.php
+++ b/src/MagentoHackathon/Composer/Magento/Parser/PackageXmlParser.php
@@ -64,6 +64,8 @@ class PackageXmlParser implements Parser
                     foreach ($target->children() as $child) {
                         foreach ($this->getElementPaths($child) as $elementPath) {
                             $relativePath = $basePath . '/' . $elementPath;
+                            //remove the any trailing './' or '.' from the targets base-path.
+                            $relativePath = preg_replace('#^[\/\.]*#', '', $relativePath);
                             $map[] = array($relativePath, $relativePath);
                         }
                     }

--- a/tests/MagentoHackathon/Composer/Magento/GitIgnoreTest.php
+++ b/tests/MagentoHackathon/Composer/Magento/GitIgnoreTest.php
@@ -29,11 +29,11 @@ class GitIgnoreTest extends \PHPUnit_Framework_TestCase
 
     public function testIfFileExistsExistingLinesAreLoaded()
     {
-        $lines = array('line1', 'line2');
+        $lines = array('/line1', '/line2');
         file_put_contents($this->gitIgnoreFile, implode("\n", $lines));
         $gitIgnore = new GitIgnore($this->gitIgnoreFile);
         $this->assertFileExists($this->gitIgnoreFile);
-        $this->assertSame($lines, $gitIgnore->getEntries());
+        $this->assertSame(['/line1', '/line2'], $gitIgnore->getEntries());
     }
 
     public function testAddEntryDoesNotAddDuplicates()
@@ -57,26 +57,34 @@ class GitIgnoreTest extends \PHPUnit_Framework_TestCase
 
     public function testCanRemoveEntry()
     {
-        $lines = array('line1', 'line2');
+        $lines = array('/line1', '/line2');
         file_put_contents($this->gitIgnoreFile, implode("\n", $lines));
         $gitIgnore = new GitIgnore($this->gitIgnoreFile);
         $gitIgnore->removeEntry('line1');
-        $this->assertEquals(array('line2'), $gitIgnore->getEntries());
+        $this->assertEquals(array('/line2'), $gitIgnore->getEntries());
     }
 
     public function testCanAddMultipleEntries()
     {
         $gitIgnore = new GitIgnore($this->gitIgnoreFile);
         $gitIgnore->addMultipleEntries(array('file1.txt', 'file2.txt'));
-        $this->assertSame(array('file1.txt', 'file2.txt'), $gitIgnore->getEntries());
+        $this->assertSame(array('/file1.txt', '/file2.txt'), $gitIgnore->getEntries());
     }
 
     public function testCanRemoveMultipleEntries()
     {
-        $lines = array('line1', 'line2');
+        $lines = array('/line1', '/line2');
         file_put_contents($this->gitIgnoreFile, implode("\n", $lines));
         $gitIgnore = new GitIgnore($this->gitIgnoreFile);
         $gitIgnore->removeMultipleEntries(array('line1', 'line2'));
         $this->assertSame(array(), $gitIgnore->getEntries());
+    }
+
+    public function testForwardSlashIsPrePendedToPath()
+    {
+        $gitIgnore = new GitIgnore($this->gitIgnoreFile);
+        $gitIgnore->addEntry('file1.txt');
+        $gitIgnore->addEntry('/file2.txt');
+        $this->assertSame(['/file1.txt', '/file2.txt'], $gitIgnore->getEntries());
     }
 }

--- a/tests/MagentoHackathon/Composer/Magento/Parser/PackageXmlParserTest.php
+++ b/tests/MagentoHackathon/Composer/Magento/Parser/PackageXmlParserTest.php
@@ -28,36 +28,36 @@ class PackageXmlParserTest extends \PHPUnit_Framework_TestCase
 
         $expected = array (
             array(
-                './app/code/community/Some/Module/Block/Block.php',
-                './app/code/community/Some/Module/Block/Block.php'
+                'app/code/community/Some/Module/Block/Block.php',
+                'app/code/community/Some/Module/Block/Block.php'
             ),
             array(
-                './app/code/community/Some/Module/Helper/Data.php',
-                './app/code/community/Some/Module/Helper/Data.php'
+                'app/code/community/Some/Module/Helper/Data.php',
+                'app/code/community/Some/Module/Helper/Data.php'
             ),
             array(
-                './app/code/community/Some/Module/Model/Model.php',
-                './app/code/community/Some/Module/Model/Model.php'
+                'app/code/community/Some/Module/Model/Model.php',
+                'app/code/community/Some/Module/Model/Model.php'
             ),
             array(
-                './app/code/community/Some/Module/etc/config.xml',
-                './app/code/community/Some/Module/etc/config.xml'
+                'app/code/community/Some/Module/etc/config.xml',
+                'app/code/community/Some/Module/etc/config.xml'
             ),
             array(
-                './app/design/adminhtml/default/default/layout/layout.xml',
-                './app/design/adminhtml/default/default/layout/layout.xml'
+                'app/design/adminhtml/default/default/layout/layout.xml',
+                'app/design/adminhtml/default/default/layout/layout.xml'
             ),
             array(
-                './app/design/adminhtml/default/default/template/module/template.phtml',
-                './app/design/adminhtml/default/default/template/module/template.phtml'
+                'app/design/adminhtml/default/default/template/module/template.phtml',
+                'app/design/adminhtml/default/default/template/module/template.phtml'
             ),
             array(
-                './app/etc/modules/Some_Module.xml',
-                './app/etc/modules/Some_Module.xml'
+                'app/etc/modules/Some_Module.xml',
+                'app/etc/modules/Some_Module.xml'
             ),
             array(
-                './skin/frontend/base/default/images/somemodule/image.png',
-                './skin/frontend/base/default/images/somemodule/image.png'
+                'skin/frontend/base/default/images/somemodule/image.png',
+                'skin/frontend/base/default/images/somemodule/image.png'
             ),
         );
 
@@ -77,8 +77,8 @@ class PackageXmlParserTest extends \PHPUnit_Framework_TestCase
         $parser = new PackageXmlParser(vfsStream::url('root/PackageXmlInvalidTarget.xml'));
         $expected = array (
             array(
-                './app/code/community/Some/Module/Block/Block.php',
-                './app/code/community/Some/Module/Block/Block.php'
+                'app/code/community/Some/Module/Block/Block.php',
+                'app/code/community/Some/Module/Block/Block.php'
             ),
         );
 
@@ -90,8 +90,8 @@ class PackageXmlParserTest extends \PHPUnit_Framework_TestCase
         $parser = new PackageXmlParser(vfsStream::url('root/PackageXmlInvalidPath.xml'));
         $expected = array (
             array(
-                './app/code/community/Some/Module/Block/Block.php',
-                './app/code/community/Some/Module/Block/Block.php'
+                'app/code/community/Some/Module/Block/Block.php',
+                'app/code/community/Some/Module/Block/Block.php'
             ),
         );
 


### PR DESCRIPTION
Package XMl mappings have `./` prepended to them, because the base paths from `res/target.xml` are prepended to each mapping. This causes issues when updating the `gitignore` as the `gitignore` prepends `/` to the paths. This results in a path like `/./app/code/community/EcomDev/PHPUnitTest` in the `gitignore`. The fix as I see it is to just remove the first 2 characters of the file path from the mappings generated by `\MagentoHackathon\Composer\Magento\Parser\PackageXmlParser`. 

Fixes #48 