### PR TITLE
Remove gitignore entries when un-installing a package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
+- Added functionality to remove entries from the git-ignore file when a module is uninstalled
 
 
 ## [3.0.4] - 2015-07-12

--- a/src/MagentoHackathon/Composer/Magento/Event/PackageUnInstallEvent.php
+++ b/src/MagentoHackathon/Composer/Magento/Event/PackageUnInstallEvent.php
@@ -4,7 +4,6 @@ namespace MagentoHackathon\Composer\Magento\Event;
 
 use Composer\EventDispatcher\Event;
 use Composer\Package\PackageInterface;
-use MagentoHackathon\Composer\Magento\Deploy\Manager\Entry;
 use MagentoHackathon\Composer\Magento\InstalledPackage;
 
 /**
@@ -18,21 +17,15 @@ class PackageUnInstallEvent extends Event
      * @var InstalledPackage
      */
     protected $package;
-    /**
-     * @var PackageInterface
-     */
-    protected $composerPackage;
 
     /**
      * @param string           $name
      * @param InstalledPackage $package
-     * @param PackageInterface $composerPackage
      */
-    public function __construct($name, InstalledPackage $package, PackageInterface $composerPackage)
+    public function __construct($name, InstalledPackage $package)
     {
         parent::__construct($name);
         $this->package = $package;
-        $this->composerPackage = $composerPackage;
     }
 
     /**
@@ -44,10 +37,10 @@ class PackageUnInstallEvent extends Event
     }
 
     /**
-     * @return PackageInterface
+     * @return array
      */
-    public function getComposerPackage()
+    public function getInstalledFiles()
     {
-        return $this->composerPackage;
+        return $this->package->getInstalledFiles();
     }
 }

--- a/src/MagentoHackathon/Composer/Magento/GitIgnoreListener.php
+++ b/src/MagentoHackathon/Composer/Magento/GitIgnoreListener.php
@@ -3,6 +3,7 @@
 namespace MagentoHackathon\Composer\Magento;
 
 use MagentoHackathon\Composer\Magento\Event\PackageDeployEvent;
+use MagentoHackathon\Composer\Magento\Event\PackageUnInstallEvent;
 
 /**
  * Class GitIgnoreListener
@@ -26,21 +27,26 @@ class GitIgnoreListener
     }
 
     /**
-     * Add any files which were deployed to the .gitignore
-     * Remove any files which were removed to the .gitignore
+     * Add any files which were installed to the .gitignore
      *
      * @param PackageDeployEvent $packageDeployEvent
      */
-    public function __invoke(PackageDeployEvent $packageDeployEvent)
+    public function addNewInstalledFiles(PackageDeployEvent $packageDeployEvent)
     {
         $this->gitIgnore->addMultipleEntries(
             $packageDeployEvent->getDeployEntry()->getDeployStrategy()->getDeployedFiles()
         );
+        $this->gitIgnore->write();
+    }
 
-        $this->gitIgnore->removeMultipleEntries(
-            $packageDeployEvent->getDeployEntry()->getDeployStrategy()->getRemovedFiles()
-        );
-
+    /**
+     * Remove any files which were removed to the .gitignore
+     *
+     * @param PackageUnInstallEvent $e
+     */
+    public function removeUnInstalledFiles(PackageUnInstallEvent $e)
+    {
+        $this->gitIgnore->removeMultipleEntries($e->getInstalledFiles());
         $this->gitIgnore->write();
     }
 }

--- a/src/MagentoHackathon/Composer/Magento/ModuleManager.php
+++ b/src/MagentoHackathon/Composer/Magento/ModuleManager.php
@@ -122,9 +122,9 @@ class ModuleManager
             return $magentoRootDir.$path;
         };
         foreach ($packagesToRemove as $remove) {
-            //$this->eventManager->dispatch(new PackageUnInstallEvent('pre-package-uninstall', $remove));
+            $this->eventManager->dispatch(new PackageUnInstallEvent('pre-package-uninstall', $remove));
             $this->unInstallStrategy->unInstall(array_map($addBasePath, $remove->getInstalledFiles()));
-            //$this->eventManager->dispatch(new PackageUnInstallEvent('post-package-uninstall', $remove));
+            $this->eventManager->dispatch(new PackageUnInstallEvent('post-package-uninstall', $remove));
             $this->installedPackageRepository->remove($remove);
         }
     }

--- a/src/MagentoHackathon/Composer/Magento/Plugin.php
+++ b/src/MagentoHackathon/Composer/Magento/Plugin.php
@@ -108,7 +108,10 @@ class Plugin implements PluginInterface, EventSubscriberInterface
 
         if ($this->config->hasAutoAppendGitignore()) {
             $gitIgnoreLocation = sprintf('%s/.gitignore', $this->config->getMagentoRootDir());
-            $eventManager->listen('post-package-deploy', new GitIgnoreListener(new GitIgnore($gitIgnoreLocation)));
+            $gitIgnore = new GitIgnoreListener(new GitIgnore($gitIgnoreLocation));
+
+            $eventManager->listen('post-package-deploy', [$gitIgnore, 'addNewInstalledFiles']);
+            $eventManager->listen('post-package-uninstall', [$gitIgnore, 'removeUnInstalledFiles']);
         }
 
         $io = $this->io;

--- a/tests/MagentoHackathon/Composer/Magento/PluginTest.php
+++ b/tests/MagentoHackathon/Composer/Magento/PluginTest.php
@@ -86,9 +86,14 @@ class PluginTest extends \PHPUnit_Framework_TestCase
         $this->composer->setPackage($rootPackage);
 
         $this->eventManager
-            ->expects($this->once())
+            ->expects($this->at(0))
             ->method('listen')
-            ->with('post-package-deploy', $this->isInstanceOf('MagentoHackathon\Composer\Magento\GitIgnoreListener'));
+            ->with('post-package-deploy', $this->isType('array'));
+
+        $this->eventManager
+            ->expects($this->at(1))
+            ->method('listen')
+            ->with('post-package-uninstall', $this->isType('array'));
 
         $this->plugin->activate($this->composer, $this->io);
     }


### PR DESCRIPTION
Uninstalling does currently not trigger events for the git-ignore listener to be triggered. This fixes that with some slight amends.