### PR TITLE
Remove empty directories up to the root dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed issue [#48](https://github.com/Cotya/magento-composer-installer/issues/48): Package XML mappings have './' prepended to them which breaks git-ignore functionality. Also explicitly adds a fw-slash to git-ignore paths, if one does not exist already.
 - Added functionality to remove entries from the git-ignore file when a module is uninstalled
 
+- Fixed an issue where empty directories were left behind after un-installing a module. If a structure like `/folder1/folder2/file1.txt` was created, and both folders were created by the module. Only `folder2` would be removed. It now traverses up-to the root-dir removing any empty directories. 
 
 ## [3.0.4] - 2015-07-12
 - Added PR [#40](https://github.com/Cotya/magento-composer-installer/pull/40): extra config option to skip repository suggestions

--- a/src/MagentoHackathon/Composer/Magento/ModuleManager.php
+++ b/src/MagentoHackathon/Composer/Magento/ModuleManager.php
@@ -78,16 +78,24 @@ class ModuleManager
         $packagesToInstall  = $this->getInstalls($currentComposerInstalledPackages);
 
         $this->doRemoves($packagesToRemove);
-        //$this->doInstalls($packagesToInstall);
+        $this->doInstalls($packagesToInstall);
 
+        return array(
+            $packagesToRemove,
+            $packagesToInstall
+        );
+    }
 
-
+    /**
+     * @param PackageInterface[] $packagesToInstall
+     */
+    public function doInstalls(array $packagesToInstall)
+    {
         foreach ($packagesToInstall as $install) {
             $installStrategy = $this->installStrategyFactory->make(
                 $install,
                 $this->getPackageSourceDirectory($install)
             );
-
 
             $deployEntry = new Entry();
             $deployEntry->setPackageName($install->getPrettyName());
@@ -105,11 +113,6 @@ class ModuleManager
                 $files
             ));
         }
-
-        return array(
-            $packagesToRemove,
-            $packagesToInstall
-        );
     }
 
     /**
@@ -117,13 +120,9 @@ class ModuleManager
      */
     public function doRemoves(array $packagesToRemove)
     {
-        $magentoRootDir = $this->config->getMagentoRootDir();
-        $addBasePath = function ($path) use ($magentoRootDir) {
-            return $magentoRootDir.$path;
-        };
         foreach ($packagesToRemove as $remove) {
             $this->eventManager->dispatch(new PackageUnInstallEvent('pre-package-uninstall', $remove));
-            $this->unInstallStrategy->unInstall(array_map($addBasePath, $remove->getInstalledFiles()));
+            $this->unInstallStrategy->unInstall($remove->getInstalledFiles());
             $this->eventManager->dispatch(new PackageUnInstallEvent('post-package-uninstall', $remove));
             $this->installedPackageRepository->remove($remove);
         }

--- a/src/MagentoHackathon/Composer/Magento/Plugin.php
+++ b/src/MagentoHackathon/Composer/Magento/Plugin.php
@@ -445,7 +445,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
                 ),
                 $this->getEventManager(),
                 $this->config,
-                new UnInstallStrategy($this->filesystem),
+                new UnInstallStrategy($this->filesystem, $this->config->getMagentoRootDir()),
                 new InstallStrategyFactory($this->config, new ParserFactory($this->config))
             );
         }

--- a/src/MagentoHackathon/Composer/Magento/UnInstallStrategy/UnInstallStrategy.php
+++ b/src/MagentoHackathon/Composer/Magento/UnInstallStrategy/UnInstallStrategy.php
@@ -18,12 +18,20 @@ class UnInstallStrategy implements UnInstallStrategyInterface
     protected $fileSystem;
 
     /**
-     * @param FileSystem $fileSystem
+     * The root dir for uninstalling from. Should be project root.
+     *
+     * @var string
      */
-    public function __construct(FileSystem $fileSystem)
-    {
+    protected $rootDir;
 
-        $this->fileSystem = $fileSystem;
+    /**
+     * @param FileSystem $fileSystem
+     * @param string     $rootDir
+     */
+    public function __construct(FileSystem $fileSystem, $rootDir)
+    {
+        $this->fileSystem   = $fileSystem;
+        $this->rootDir      = $rootDir;
     }
 
     /**
@@ -34,6 +42,8 @@ class UnInstallStrategy implements UnInstallStrategyInterface
     public function unInstall(array $files)
     {
         foreach ($files as $file) {
+            $file = $this->rootDir . $file;
+
             /*
             because of different reasons the file can be already gone.
             example:
@@ -45,8 +55,10 @@ class UnInstallStrategy implements UnInstallStrategyInterface
             if (file_exists($file) xor is_link($file)) {
                 $this->fileSystem->unlink($file);
 
-                if ($this->fileSystem->isDirEmpty(dirname($file))) {
-                    $this->fileSystem->removeDirectory(dirname($file));
+                $parentDir = dirname($file);
+                while ($this->fileSystem->isDirEmpty($parentDir) && $parentDir !== $this->rootDir) {
+                    $this->fileSystem->removeDirectory($parentDir);
+                    $parentDir = dirname($parentDir);
                 }
             }
         }

--- a/tests/MagentoHackathon/Composer/Magento/UninstallStrategy/UnInstallStrategyTest.php
+++ b/tests/MagentoHackathon/Composer/Magento/UninstallStrategy/UnInstallStrategyTest.php
@@ -1,0 +1,91 @@
+<?php
+
+use Composer\Util\Filesystem;
+use MagentoHackathon\Composer\Magento\UnInstallStrategy\UnInstallStrategy;
+
+/**
+ * Class UnInstallStrategyTest
+ * @author Aydin Hassan <aydin@hotmail.co.uk>
+ */
+class UnInstallStrategyTest extends PHPUnit_Framework_TestCase
+{
+    protected $testDirectory;
+
+    public function testUnInstall()
+    {
+        $this->testDirectory    = sprintf('%s/%s', realpath(sys_get_temp_dir()), $this->getName());
+        $this->testDirectory    = str_replace('\\', '/', $this->testDirectory);
+        $rootDir                = $this->testDirectory . '/root';
+        mkdir($rootDir, 0777, true);
+
+        $strategy   = new UnInstallStrategy(new FileSystem, $rootDir);
+
+        mkdir($rootDir . '/child1/secondlevelchild1', 0777, true);
+        mkdir($rootDir . '/child2/secondlevelchild2', 0777, true);
+        mkdir($rootDir . '/child3/secondlevelchild3', 0777, true);
+        mkdir($rootDir . '/child4/secondlevelchild4', 0777, true);
+
+        touch($rootDir . '/child1/secondlevelchild1/file1.txt');
+        touch($rootDir . '/child2/secondlevelchild2/file2.txt');
+        touch($rootDir . '/child3/secondlevelchild3/file3.txt');
+        touch($rootDir . '/child4/secondlevelchild4/file4.txt');
+
+        $files = [
+            '/child1/secondlevelchild1/file1.txt',
+            '/child2/secondlevelchild2/file2.txt',
+            '/child3/secondlevelchild3/file3.txt',
+            '/child4/secondlevelchild4/file4.txt',
+        ];
+
+        $strategy->unInstall($files);
+
+        $this->assertFileExists($rootDir);
+        $this->assertFileNotExists($rootDir . '/child1');
+        $this->assertFileNotExists($rootDir . '/child2');
+        $this->assertFileNotExists($rootDir . '/child3');
+        $this->assertFileNotExists($rootDir . '/child4');
+    }
+
+    public function testUnInstallDoesNotRemoveOtherFiles()
+    {
+        $this->testDirectory    = sprintf('%s/%s', realpath(sys_get_temp_dir()), $this->getName());
+        $this->testDirectory    = str_replace('\\', '/', $this->testDirectory);
+        $rootDir                = $this->testDirectory . '/root';
+        mkdir($rootDir, 0777, true);
+
+        $strategy   = new UnInstallStrategy(new FileSystem, $rootDir);
+
+        mkdir($rootDir . '/child1/secondlevelchild1', 0777, true);
+        mkdir($rootDir . '/child2/secondlevelchild2', 0777, true);
+        mkdir($rootDir . '/child3/secondlevelchild3', 0777, true);
+        mkdir($rootDir . '/child4/secondlevelchild4', 0777, true);
+
+        touch($rootDir . '/child1/secondlevelchild1/file1.txt');
+        touch($rootDir . '/child2/secondlevelchild2/file2.txt');
+        touch($rootDir . '/child3/secondlevelchild3/file3.txt');
+        touch($rootDir . '/child4/secondlevelchild4/file4.txt');
+        touch($rootDir . '/child4/secondlevelchild4/file5.txt');
+
+        $files = [
+            '/child1/secondlevelchild1/file1.txt',
+            '/child2/secondlevelchild2/file2.txt',
+            '/child3/secondlevelchild3/file3.txt',
+            '/child4/secondlevelchild4/file4.txt',
+        ];
+
+        $strategy->unInstall($files);
+
+        $this->assertFileExists($rootDir);
+        $this->assertFileNotExists($rootDir . '/child1');
+        $this->assertFileNotExists($rootDir . '/child2');
+        $this->assertFileNotExists($rootDir . '/child3');
+        $this->assertFileNotExists($rootDir . '/child4/secondlevelchild4/file4.txt');
+        $this->assertFileExists($rootDir . '/child4/secondlevelchild4/file5.txt');
+    }
+
+    public function tearDown()
+    {
+        $fs = new Filesystem;
+        $fs->remove($this->testDirectory);
+    }
+}


### PR DESCRIPTION
When uninstalling modules, empty directories are left. Traverse up to the root, removing each empty directory for each file which is removed. 

This will probably need rebasing after #50 and #49 