### PR TITLE
Fixed magento-deploy-ignore nodes ignoring parent directory, and enabled ignoring subdirectories.

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/Deploystrategy/Copy.php
+++ b/src/MagentoHackathon/Composer/Magento/Deploystrategy/Copy.php
@@ -100,6 +100,11 @@ class Copy extends DeploystrategyAbstract
             \RecursiveIteratorIterator::SELF_FIRST);
 
         foreach ($iterator as $item) {
+            $subDest = $dest . '/' . $iterator->getSubPathName();
+            if ($this->isDestinationIgnored($subDest) || in_array($item->getFileName(), array('.', '..'))) {
+                continue;
+            }
+
             $subDestPath = $destPath . '/' . $iterator->getSubPathName();
             if ($item->isDir()) {
                 if (! file_exists($subDestPath)) {

--- a/src/MagentoHackathon/Composer/Magento/Deploystrategy/DeploystrategyAbstract.php
+++ b/src/MagentoHackathon/Composer/Magento/Deploystrategy/DeploystrategyAbstract.php
@@ -276,7 +276,7 @@ abstract class DeploystrategyAbstract
         $destination = str_replace('/./', '/', $destination);
         $destination = str_replace('//', '/', $destination);
         foreach ($this->ignoredMappings as $ignored) {
-            if (0 === strpos($ignored, $destination)) {
+            if (false !== strpos($destination, $ignored)) {
                 return true;
             }
         }


### PR DESCRIPTION
These commits fix two issues:
- b2f44cd fixes an issue in which entries in magento-deploy-ignore were causing parent directories to be ignored. E.g., ignoring "app/Mage.php" would cause "app" to be ignored. 
- 4fff2bb adds functionality to the copy deploy strategy to allow directories not present in magento-core's mapping file and their subdirectories to be ignored. E.g. "/skin/frontend/rwd" can be ignored even though magento-core modules are mapping the "skin" folder.

[Here](https://gist.github.com/jantzenw/3a988b08fc9496f03f4a) is an example magento-deploy-ignore using these commits that has been tested for several months.
