### PR TITLE
WIP - Get tests running on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,7 @@ matrix:
 
 sudo: false
 
-cache:
-  directories:
-  - $HOME/.composer/cache
+cache: false
 
 install:
   - pecl install SPL_Types

--- a/src/MagentoHackathon/Composer/Magento/Deploystrategy/Copy.php
+++ b/src/MagentoHackathon/Composer/Magento/Deploystrategy/Copy.php
@@ -84,6 +84,7 @@ class Copy extends DeploystrategyAbstract
             if (is_dir($destPath)) {
                 $destPath .= '/' . basename($sourcePath);
             }
+            $destPath = str_replace('\\', '/', $destPath);
             $this->addDeployedFile($destPath);
             return copy($sourcePath, $destPath);
         }
@@ -107,6 +108,7 @@ class Copy extends DeploystrategyAbstract
                     mkdir($subDestPath, 0777, true);
                 }
             } else {
+                $subDestPath = str_replace('\\', '/', $subDestPath);
                 copy($item, $subDestPath);
                 $this->addDeployedFile($subDestPath);
             }

--- a/src/MagentoHackathon/Composer/Magento/Deploystrategy/DeploystrategyAbstract.php
+++ b/src/MagentoHackathon/Composer/Magento/Deploystrategy/DeploystrategyAbstract.php
@@ -481,8 +481,11 @@ abstract class DeploystrategyAbstract
      */
     public function addDeployedFile($file)
     {
-        //strip of destination deploy location
-        $file = preg_replace(sprintf('/^%s/', preg_quote($this->getDestDir(), '/')), '', $file);
+       $destination = str_replace('\\', '/', $this->getDestDir());
+        //strip of destination deploy
+        $quoted = preg_quote($destination, '/');
+        $regex = sprintf('/^%s/', $quoted);
+        $file = preg_replace($regex, '', $file);
         $this->deployedFiles[] = $file;
     }
 

--- a/src/MagentoHackathon/Composer/Magento/Deploystrategy/Symlink.php
+++ b/src/MagentoHackathon/Composer/Magento/Deploystrategy/Symlink.php
@@ -99,6 +99,7 @@ class Symlink extends DeploystrategyAbstract
         $relSourcePath = $this->getRelativePath($destPath, $sourcePath);
 
         // Create symlink
+        $destPath = str_replace('\\', '/', $destPath);
         if (false === $this->symlink($relSourcePath, $destPath, $sourcePath)) {
             $msg = "An error occured while creating symlink\n" . $relSourcePath . " -> " . $destPath;
             if ('\\' === DIRECTORY_SEPARATOR) {

--- a/tests/MagentoHackathon/Composer/FullStack/Regression/Issue098Test.php
+++ b/tests/MagentoHackathon/Composer/FullStack/Regression/Issue098Test.php
@@ -23,31 +23,32 @@ class Issue098Test extends ComposerTestFramework\PHPUnit\FullStackTestCase
         $projectDirectory = new \SplFileInfo(self::getTempComposerProjectPath());
 
 
-        $artifactDirectory = new \SplFileInfo(__DIR__.'/../../../../../tests/FullStackTest/artifact');
+        $path = str_replace('\\', '/', __DIR__);
+        $artifactDirectory = new \SplFileInfo($path .'/../../../../../tests/FullStackTest/artifact');
 
 
         $composerJson = new  \SplTempFileObject();
-        $composerJsonContent = <<<JSON
-{
-    "repositories": [
-        {
-            "type": "artifact",
-            "url": "$artifactDirectory/"
-        }
-    ],
-    "require": {
-        "magento-hackathon/magento-composer-installer-test-sort1": "1.0.0"
-    },
-    "extra": {
-        "magento-deploysttrategy": "copy",
-        "magento-force": "override",
-        "magento-root-dir": "./magento"
-    }
 
-}
-JSON;
+        $dir = $artifactDirectory->getRealPath();
 
-        $composerJson->fwrite($composerJsonContent);
+        $json = [
+            'repositories' => [
+                [
+                    'type' => 'artifact',
+                    'url' => $artifactDirectory->getRealPath(),
+                ]
+            ],
+            'require' => [
+                'magento-hackathon/magento-composer-installer-test-sort1' => '1.0.0',
+            ],
+            'extra' => [
+                'magento-deploysttrategy' => 'copy',
+                'magento-force' => 'override',
+                'magento-root-dir' => './magento'
+            ]
+        ];
+
+        $composerJson->fwrite(json_encode($json, JSON_PRETTY_PRINT));
 
         $composer->install($projectDirectory, $composerJson);
 
@@ -56,32 +57,30 @@ JSON;
         );
 
         $composerJson = new  \SplTempFileObject();
-        $composerJsonContent = <<<JSON
-{
-    "repositories": [
-        {
-            "type": "artifact",
-            "url": "$artifactDirectory/"
-        }
-    ],
-    "require": {
-        "magento-hackathon/magento-composer-installer-test-sort1": "1.0.0",
-        "magento-hackathon/magento-composer-installer": "*"
-    },
-    "extra": {
-        "magento-deploysttrategy": "copy",
-        "magento-force": "override",
-        "magento-root-dir": "./magento"
-    }
 
-}
-JSON;
+        $json = [
+            'repositories' => [
+                [
+                    'type' => 'artifact',
+                    'url' => $artifactDirectory->getRealPath(),
+                ]
+            ],
+            'require' => [
+                'magento-hackathon/magento-composer-installer-test-sort1' => '1.0.0',
+                'magento-hackathon/magento-composer-installer' => '*'
+            ],
+            'extra' => [
+                'magento-deploysttrategy' => 'copy',
+                'magento-force' => 'override',
+                'magento-root-dir' => './magento'
+            ]
+        ];
 
-        $composerJson->fwrite($composerJsonContent);
-        
+        $composerJson->fwrite(json_encode($json, JSON_PRETTY_PRINT));
+
         $composer->update($projectDirectory, $composerJson);
-        
-        
+
+
         $this->assertFileExists(
             $projectDirectory->getPathname().'/magento/app/design/frontend/test/default/installSort/test1.phtml'
         );

--- a/tests/MagentoHackathon/Composer/FullStack/Regression/Issue139Test.php
+++ b/tests/MagentoHackathon/Composer/FullStack/Regression/Issue139Test.php
@@ -13,7 +13,6 @@ use Cotya\ComposerTestFramework;
 class Issue139Test extends ComposerTestFramework\PHPUnit\FullStackTestCase
 {
 
-
     /**
      * @group regression
      */
@@ -27,33 +26,31 @@ class Issue139Test extends ComposerTestFramework\PHPUnit\FullStackTestCase
 
 
         $composerJson = new  \SplTempFileObject();
-        $composerJsonContent = <<<JSON
-{
-    "repositories": [
-        {
-            "type": "composer",
-            "url": "http://packages.firegento.com"
-        },
-        {
-            "type": "artifact",
-            "url": "$artifactDirectory/"
-        }
-    ],
-    "require": {
-        "connect20/mage_all_latest": "*",
-        "magento-hackathon/magento-composer-installer": "*",
-        "composer/composer": "*@dev"
-    },
-    "extra": {
-        "magento-deploysttrategy": "copy",
-        "magento-force": "override",
-        "magento-root-dir": "./web"
-    }
 
-}
-JSON;
+        $json = [
+            'repositories' => [
+                [
+                    'type' => 'composer',
+                    'url' => 'http://packages.firegento.com'
+                ],
+                [
+                    'type' => 'artifact',
+                    'url' => $artifactDirectory->getRealPath(),
+                ]
+            ],
+            'require' => [
+                'connect20/mage_all_latest' => '*',
+                'magento-hackathon/magento-composer-installer' => '*',
+                'composer/composer' => '*@dev'
+            ],
+            'extra' => [
+                'magento-deploysttrategy' => 'copy',
+                'magento-force' => 'override',
+                'magento-root-dir' => './web'
+            ]
+        ];
 
-        $composerJson->fwrite($composerJsonContent);
+        $composerJson->fwrite(json_encode($json, JSON_PRETTY_PRINT));
 
         $composer->install($projectDirectory, $composerJson);
 

--- a/tests/MagentoHackathon/Composer/FullStack/Regression/IssueC039Test.php
+++ b/tests/MagentoHackathon/Composer/FullStack/Regression/IssueC039Test.php
@@ -23,68 +23,60 @@ class IssueC039Test extends ComposerTestFramework\PHPUnit\FullStackTestCase
             '/build/app/design/frontend/test/default/updateFileRemove/design/test1.phtml';
 
         $composerJson = new  \SplTempFileObject();
-        $composerJsonContent = <<<JSON
-{
-    "repositories": [
-        {
-            "type": "composer",
-            "url": "http://packages.firegento.com"
-        },
-        {
-            "type": "artifact",
-            "url": "$artifactDirectory/"
-        }
-    ],
-    "require": {
-        "magento-hackathon/magento-composer-installer": "999.0.0",
-        "magento-hackathon/magento-composer-installer-test-updateFileRemove": "1.0.0"
-    },
-    "extra": {
-        "magento-deploysttrategy": "symlink",
-        "magento-root-dir": "./build"
-    }
 
-}
-JSON;
+        $json = [
+            'repositories' => [
+                [
+                    'type' => 'composer',
+                    'url' => 'http://packages.firegento.com'
+                ],
+                [
+                    'type' => 'artifact',
+                    'url' => $artifactDirectory->getRealPath(),
+                ]
+            ],
+            'require' => [
+                'magento-hackathon/magento-composer-installer' => '999.0.0',
+                'magento-hackathon/magento-composer-installer-test-updateFileRemove' => '1.0.0'
+            ],
+            'extra' => [
+                'magento-deploysttrategy' => 'symlink',
+                'magento-root-dir' => './build'
+            ]
+        ];
 
-        $composerJson->fwrite($composerJsonContent);
-
+        $composerJson->fwrite(json_encode($json, JSON_PRETTY_PRINT));
         $composer->install($projectDirectory, $composerJson);
-
         $this->assertFileExists($testFilePath);
 
 
 
         $composerJson = new  \SplTempFileObject();
-        $composerJsonContent = <<<JSON
-{
-    "repositories": [
-        {
-            "type": "composer",
-            "url": "http://packages.firegento.com"
-        },
-        {
-            "type": "artifact",
-            "url": "$artifactDirectory/"
-        }
-    ],
-    "require": {
-        "magento-hackathon/magento-composer-installer": "*"
-    },
-    "extra": {
-        "magento-deploysttrategy": "symlink",
-        "magento-root-dir": "./build"
-    }
 
-}
-JSON;
+        $json = [
+            'repositories' => [
+                [
+                    'type' => 'composer',
+                    'url' => 'http://packages.firegento.com'
+                ],
+                [
+                    'type' => 'artifact',
+                    'url' => $artifactDirectory->getRealPath(),
+                ]
+            ],
+            'require' => [
+                'magento-hackathon/magento-composer-installer' => '*',
+            ],
+            'extra' => [
+                'magento-deploysttrategy' => 'symlink',
+                'magento-root-dir' => './build'
+            ]
+        ];
 
-        $composerJson->fwrite($composerJsonContent);
-
+        $composerJson->fwrite(json_encode($json, JSON_PRETTY_PRINT));
         $composer->update($projectDirectory, $composerJson);
 
         $this->assertFileNotExists($testFilePath);
         $this->assertFalse(is_link($testFilePath), 'There is still a link');
-        
     }
 }

--- a/tests/MagentoHackathon/Composer/Magento/Deploystrategy/AbstractTest.php
+++ b/tests/MagentoHackathon/Composer/Magento/Deploystrategy/AbstractTest.php
@@ -51,8 +51,9 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->filesystem = new \Composer\Util\Filesystem();
-        $this->sourceDir = sys_get_temp_dir() . DS . $this->getName() . DS . "module_dir";
-        $this->destDir = sys_get_temp_dir() . DS . $this->getName() . DS . "magento_dir";
+        $tmpDir = str_replace('\\', '/', sys_get_temp_dir());
+        $this->sourceDir = sprintf('%s/%s/module_dir', $tmpDir, $this->getName());
+        $this->destDir = sprintf('%s/%s/magento_dir', $tmpDir, $this->getName());
         $this->filesystem->ensureDirectoryExists($this->sourceDir);
         $this->filesystem->ensureDirectoryExists($this->destDir);
 
@@ -437,5 +438,14 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
             array($file1, $file2),
             $this->strategy->getRemovedFiles()
         );
+    }
+
+    /**
+     * @param string $str
+     * @return string
+     */
+    protected function replaceSlashes($str)
+    {
+        return str_replace('\\', '/', $str);
     }
 }

--- a/tests/MagentoHackathon/Composer/Magento/Deploystrategy/CopyTest.php
+++ b/tests/MagentoHackathon/Composer/Magento/Deploystrategy/CopyTest.php
@@ -31,12 +31,12 @@ class CopyTest extends AbstractTest
         $sourceRoot = 'root';
         $sourceContents = "subdir/subdir/test.xml";
 
-        $this->mkdir($this->sourceDir . DS . $sourceRoot . DS . dirname($sourceContents));
-        touch($this->sourceDir . DS . $sourceRoot . DS . $sourceContents);
+        $this->mkdir(sprintf('%s/%s/%s', $this->sourceDir, $sourceRoot, dirname($sourceContents)));
+        touch(sprintf('%s/%s/%s', $this->sourceDir, $sourceRoot, $sourceContents));
 
         // intentionally using a differnt name to verify solution doesn't rely on identical src/dest paths
         $dest = "dest/root";
-        $this->mkdir($this->destDir . DS . $dest);
+        $this->mkdir(sprintf('%s/%s', $this->destDir, $dest));
 
         $testTarget = $this->destDir . DS . $dest . DS . $sourceContents;
         $this->strategy->setCurrentMapping(array($sourceRoot, $dest));
@@ -55,15 +55,14 @@ class CopyTest extends AbstractTest
         $sourceContents = "app/code/test.php";
         
         //create target directory before
-        $this->mkdir($this->destDir . DS . 'app' . DS . 'code');
-
-        $this->mkdir($this->sourceDir . DS . dirname($sourceContents));
-        touch($this->sourceDir . DS . $sourceContents);
+        $this->mkdir(sprintf('%s/app/code', $this->destDir));
+        $this->mkdir(sprintf('%s/app/code', $this->sourceDir));
+        touch(sprintf('%s/%s', $this->sourceDir, $sourceContents));
 
         $dest = "dest/root";
-        $this->mkdir($this->destDir . DS . $dest);
+        $this->mkdir(sprintf('%s/%s/', $this->destDir, $dest));
 
-        $testTarget = $this->destDir . DS . $sourceContents;
+        $testTarget = sprintf('%s/%s', $this->destDir, $sourceContents);
         $this->strategy->setMappings(array(array('*', '/')));
 
         $this->strategy->deploy();
@@ -72,7 +71,7 @@ class CopyTest extends AbstractTest
         $this->strategy->setIsForced(true);
         $this->strategy->deploy();
 
-        $this->assertFileNotExists($this->destDir . DS . 'app' . DS . 'app' . DS . 'code' . DS . 'test.php');
+        $this->assertFileNotExists(sprintf('%s/app/app/code/test.php', $this->destDir));
         
     }
 
@@ -90,9 +89,6 @@ class CopyTest extends AbstractTest
 
         $testTarget = $this->destDir . DS . $dest . DS . $sourceContents;
         $this->strategy->setCurrentMapping(array($sourceRoot, $dest));
-
-        $this->strategy->create($sourceRoot, $dest);
-        $this->assertFileExists($testTarget);
 
         $this->strategy->setIsForced(true);
         $this->strategy->create($sourceRoot, $dest);

--- a/tests/MagentoHackathon/Composer/Magento/Deploystrategy/SymlinkTest.php
+++ b/tests/MagentoHackathon/Composer/Magento/Deploystrategy/SymlinkTest.php
@@ -38,19 +38,19 @@ class SymlinkTest extends AbstractTest
 
     public function testChangeLink()
     {
-        $wrongFile = $this->sourceDir . DS . 'wrong';
-        $rightFile = $this->sourceDir . DS . 'right';
-        $link = $this->destDir . DS . 'link';
+        $wrongFile  = sprintf('%s/%s', $this->sourceDir, 'wrong');
+        $rightFile  = sprintf('%s/%s', $this->sourceDir, 'right');
+        $link       = sprintf('%s/link', $this->destDir);
 
         touch($wrongFile);
         touch($rightFile);
         @unlink($link);
 
         symlink($wrongFile, $link);
-        $this->assertEquals($wrongFile, readlink($link));
+        $this->assertEquals($wrongFile, $this->replaceSlashes(readlink($link)));
 
         $this->strategy->create(basename($rightFile), basename($link));
-        $this->assertEquals(realpath($rightFile), realpath(dirname($rightFile) . DS . readlink($link)));
+        $this->assertEquals($this->replaceSlashes(realpath($rightFile)), $this->replaceSlashes(readlink($link)));
     }
 
     public function testTargetDirWithChildDirExists()
@@ -119,16 +119,16 @@ class SymlinkTest extends AbstractTest
 
     public function testDeployedFilesAreStored()
     {
-        $src = 'local1.xml';
-        $dest = 'local2.xml';
-        touch($this->sourceDir . DIRECTORY_SEPARATOR . $src);
-        $this->assertTrue(is_readable($this->sourceDir . DIRECTORY_SEPARATOR . $src));
-        $this->assertFalse(is_readable($this->destDir . DIRECTORY_SEPARATOR . $dest));
-        $this->strategy->create($src, $dest);
-        $this->assertTrue(is_readable($this->destDir . DIRECTORY_SEPARATOR . $dest));
-        unlink($this->destDir . DIRECTORY_SEPARATOR . $dest);
-        $this->strategy->clean($this->destDir . DIRECTORY_SEPARATOR . $dest);
-        $this->assertFalse(is_readable($this->destDir . DIRECTORY_SEPARATOR . $dest));
+        $source         = sprintf('%s/local1.xml', $this->sourceDir);
+        $destination    = sprintf('%s/local2.xml', $this->destDir);
+        touch($source);
+        $this->assertTrue(is_readable($source));
+        $this->assertFalse(is_readable($destination));
+        $this->strategy->create('local1.xml', 'local2.xml');
+        $this->assertTrue(is_readable($destination));
+        unlink($destination);
+        $this->strategy->clean($destination);
+        $this->assertFalse(is_readable($destination));
 
         $this->assertSame(
             array('/local2.xml'),

--- a/tests/MagentoHackathon/Composer/Magento/Deploystrategy/SymlinkTest.php
+++ b/tests/MagentoHackathon/Composer/Magento/Deploystrategy/SymlinkTest.php
@@ -36,8 +36,33 @@ class SymlinkTest extends AbstractTest
         $this->assertFalse(is_readable($this->destDir . DIRECTORY_SEPARATOR . $dest));
     }
 
-    public function testChangeLink()
+    public function testChangeLinkLinux()
     {
+	if ($this->isWindows()) {
+            $this->markTestSkipped('Test only runs on Linux');
+        }
+
+        $wrongFile  = sprintf('%s/%s', $this->sourceDir, 'wrong');
+        $rightFile  = sprintf('%s/%s', $this->sourceDir, 'right');
+        $link       = sprintf('%s/link', $this->destDir);
+
+        touch($wrongFile);
+        touch($rightFile);
+        @unlink($link);
+
+        symlink($wrongFile, $link);
+        $this->assertEquals($wrongFile, $this->replaceSlashes(readlink($link)));
+
+        $this->strategy->create(basename($rightFile), basename($link));
+        $this->assertEquals(realpath($rightFile), realpath(dirname($rightFile) . DS . readlink($link)));
+    }
+
+    public function testChangeLinkWindows()
+    {
+        if (!$this->isWindows()) {
+            $this->markTestSkipped('Test only runs on Windows');
+        }
+
         $wrongFile  = sprintf('%s/%s', $this->sourceDir, 'wrong');
         $rightFile  = sprintf('%s/%s', $this->sourceDir, 'right');
         $link       = sprintf('%s/link', $this->destDir);
@@ -52,6 +77,7 @@ class SymlinkTest extends AbstractTest
         $this->strategy->create(basename($rightFile), basename($link));
         $this->assertEquals($this->replaceSlashes(realpath($rightFile)), $this->replaceSlashes(readlink($link)));
     }
+
 
     public function testTargetDirWithChildDirExists()
     {
@@ -155,4 +181,10 @@ class SymlinkTest extends AbstractTest
         sort($result);
         $this->assertEquals($expected, $result);
     }
+ 
+    public function isWindows()
+    {
+        return strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
+    }
+	
 }

--- a/tests/MagentoHackathon/Composer/Magento/FullStack/AbstractTest.php
+++ b/tests/MagentoHackathon/Composer/Magento/FullStack/AbstractTest.php
@@ -34,7 +34,7 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
     {
         if (getenv('TRAVIS') == "true") {
             $command = self::getProjectRoot().'/composer.phar';
-        } elseif (self::runInProjectRoot('composer.phar --version')->getExitCode() === 0) {
+        } elseif (self::runInProjectRoot('./composer.phar --version')->getExitCode() === 0) {
             $command = 'composer.phar';
         } else {
             $command = 'composer';
@@ -62,8 +62,16 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
             $name = self::$processLogCounter;
             self::$processLogCounter++;
         }
+
+        $class = get_called_class();
+        $class = explode('\\', $class);
+        $class = end($class);
+
+        $log = sprintf("%s/%s_%sOutput.log", self::getBasePath(), $class, $name);
+        $log = str_replace('\\', '/', $log);
+
         file_put_contents(
-            sprintf("%s/%s_%sOutput.log", self::getBasePath(), get_called_class(), $name),
+            $log,
             sprintf("%s\n\n%s", $process->getCommandLine(), $process->getOutput())
         );
     }

--- a/tests/generate_artifacts.php
+++ b/tests/generate_artifacts.php
@@ -20,7 +20,7 @@ $function = function() {
     $composerCommand = 'composer';
     if (getenv('TRAVIS') == "true") {
         $composerCommand = $projectPath . '/composer.phar';
-    } elseif ($runInProjectRoot('composer.phar')->getExitCode() === 0) {
+    } elseif ($runInProjectRoot('./composer.phar')->getExitCode() === 0) {
         $composerCommand = 'composer.phar';
     }
     


### PR DESCRIPTION
This is a WIP - Do not merge yet.

Most of the issues with windows are to do with paths using different slashes everywhere. There are some nasty replaces everywhere to get this working. Once the tests are passing, we should re-visit this.

Some bugs with the fullstack tests include:
* Un-escaped paths in `composer.json`
* Artefacts not generating as the setup script was not locating composer properly
* Wrong paths

This is still not finished yet, however, the unit-tests are passing in Windows now, altough one test seems to have broken on Linux, I'll take a look at this later. 

Some of the full-stack tests are passing now. However I've got an issue with paths being too-long when composer extracts artefacts so I need to figure a way to make paths shorter. 

I need https://github.com/Cotya/composer-test-framework/pull/1 & https://github.com/Cotya/composer-test-framework/pull/2 merging also, as there are some bugs with Windows there. 