### PR TITLE
5.4 should not be in allowed failures & remove 5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ php:
   - 5.6
   - 5.5
   - 5.4
-  - 5.3
   #- hhvm
   
 env:
@@ -16,8 +15,6 @@ matrix:
     - php: 5.6
       env: TEST_SUITE=Static
   allow_failures:
-    - php: 5.3
-    - php: 5.4
     - php: hhvm
     - env: TEST_SUITE=Static
 


### PR DESCRIPTION
We support 5.4 as minimum version so we should not allow failures on Travis. For the same reason there is no point running on 5.3