### PR TITLE
added functionality to include root package when deploying modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
-
+- Added functionality to include root package when deploying modules
 
 ## [3.0.5] - 2015-08-05
 - Fixed Issue [#20](https://github.com/Cotya/magento-composer-installer/issues/20): 'mklink""' is not recognized as an internal or external command, operable program or batch file.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,25 @@ Multiple deploys will not add additional lines to your `.gitignore`, they will o
 
 Documentation available [here](doc/Autoloading.md). 
 
+### Include your project in deployment
+
+When the magento-composer-installer is run, it only looks for magento-modules among your project's dependencies. Thus, if
+your project is a magento-module and you want to test it, you will need a second `composer.json` for deployment, 
+where your project is configured as a required package.
+
+If you wish to deploy your project's files (a.k.a. root package), too, you need to setup your `composer.json` as follows:
+
+```
+{
+    "type": "magento-module",
+    ...
+    "extra": {
+        "magento-root-dir": "htdocs/",
+        "include-root-package": true
+    }
+}
+```
+
 ### Testing
 
 First clone the magento-composer-installer, then install the dev-stuff (installed by default):

--- a/src/MagentoHackathon/Composer/Magento/ModuleManager.php
+++ b/src/MagentoHackathon/Composer/Magento/ModuleManager.php
@@ -3,6 +3,7 @@
 namespace MagentoHackathon\Composer\Magento;
 
 use Composer\Package\PackageInterface;
+use Composer\Package\RootPackage;
 use MagentoHackathon\Composer\Magento\Deploy\Manager\Entry;
 use MagentoHackathon\Composer\Magento\Event\EventManager;
 use MagentoHackathon\Composer\Magento\Event\PackageDeployEvent;
@@ -195,7 +196,12 @@ class ModuleManager
      */
     private function getPackageSourceDirectory(PackageInterface $package)
     {
-        $path = sprintf("%s/%s", $this->config->getVendorDir(), $package->getPrettyName());
+        if ($package instanceof RootPackage) {
+            $path = sprintf("%s/..", $this->config->getVendorDir());
+        } else {
+            $path = sprintf("%s/%s", $this->config->getVendorDir(), $package->getPrettyName());
+        }
+
         $targetDir = $package->getTargetDir();
 
         if ($targetDir) {

--- a/src/MagentoHackathon/Composer/Magento/Plugin.php
+++ b/src/MagentoHackathon/Composer/Magento/Plugin.php
@@ -215,6 +215,12 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             }
         );
 
+        if ($this->composer->getPackage()->getType() === static::PACKAGE_TYPE
+            && $this->config->getIncludeRootPackage() === true
+        ) {
+            $magentoModules[] = $this->composer->getPackage();
+        }
+
         $vendorDir = rtrim($this->composer->getConfig()->get(self::VENDOR_DIR_KEY), '/');
 
         Helper::initMagentoRootDir(

--- a/src/MagentoHackathon/Composer/Magento/ProjectConfig.php
+++ b/src/MagentoHackathon/Composer/Magento/ProjectConfig.php
@@ -35,6 +35,8 @@ class ProjectConfig
 
     const PATH_MAPPINGS_TRANSLATIONS_KEY = 'path-mapping-translations';
 
+    const INCLUDE_ROOT_PACKAGE_KEY = 'include-root-package';
+
     // Default Values
     const DEFAULT_MAGENTO_ROOT_DIR = 'root';
 
@@ -460,5 +462,21 @@ class ProjectConfig
     public function skipSuggestComposerRepositories()
     {
         return (bool) $this->fetchVarFromExtraConfig(self::EXTRA_WITH_SKIP_SUGGEST_KEY, false);
+    }
+
+    /**
+     * @param $includeRootPackage
+     */
+    public function setIncludeRootPackage($includeRootPackage)
+    {
+        $this->updateExtraConfig(self::INCLUDE_ROOT_PACKAGE_KEY, trim($includeRootPackage));
+    }
+
+    /**
+     * @return bool
+     */
+    public function getIncludeRootPackage()
+    {
+        return (bool)$this->fetchVarFromExtraConfig(self::INCLUDE_ROOT_PACKAGE_KEY);
     }
 }

--- a/tests/MagentoHackathon/Composer/FullStack/Regression/IssueC065Test.php
+++ b/tests/MagentoHackathon/Composer/FullStack/Regression/IssueC065Test.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Copyright (c) 2008-2015 dotSource GmbH.
+ * All rights reserved.
+ * http://www.dotsource.de
+ *
+ * Created:
+ * 26.08.2015
+ *
+ * Contributors:
+ * Felix Glaser - initial contents
+ *
+ * @category    Dotsource
+ */
+
+namespace MagentoHackathon\Composer\FullStack\Regression;
+
+use Composer\Util\Filesystem;
+use Cotya\ComposerTestFramework;
+
+class IssueC065Test extends ComposerTestFramework\PHPUnit\FullStackTestCase
+{
+    /** @var  ComposerTestFramework\Composer\Wrapper */
+    protected $composer;
+
+    /** @var  \SplFileInfo */
+    protected $projectDirectory;
+
+    /** @var  \SplFileInfo */
+    protected $artifactDirectory;
+
+    /** @var  string */
+    protected $testFilePath;
+
+    protected function setUp()
+    {
+        $this->composer = new ComposerTestFramework\Composer\Wrapper();
+        $this->projectDirectory = new \SplFileInfo(self::getTempComposerProjectPath());
+        $this->artifactDirectory = new \SplFileInfo(__DIR__.'/../../../../../tests/FullStackTest/artifact');
+        $this->testFilePath = $this->projectDirectory->getPathname()."/mage/app/code/local/Test/Module";
+    }
+
+    private function prepareProject()
+    {
+        $fs = new Filesystem();
+        $fs->remove($this->projectDirectory->getPathname()."/mage/app");
+        $fs->ensureDirectoryExists($this->projectDirectory->getPathname()."/app/code/local/Test/Module");
+
+        $modman = new \SplFileObject($this->projectDirectory->getPathname()."/modman", "w");
+        $modmanContent = <<<MODMAN
+app/code/local/*    app/code/local/
+MODMAN;
+
+        $modman->fwrite($modmanContent);
+    }
+
+    /**
+     * @group regression
+     */
+    public function testIncludeRootPackageNotSet()
+    {
+        $this->prepareProject();
+
+        $composerJson = new  \SplTempFileObject();
+        $composerJsonContent = <<<JSON
+{
+    "name": "test/module",
+    "type": "magento-module",
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "http://packages.firegento.com"
+        },
+        {
+            "type": "artifact",
+            "url": "$this->artifactDirectory/"
+        }
+    ],
+    "require": {
+        "magento-hackathon/magento-composer-installer": "999.0.0"
+    },
+    "extra": {
+        "magento-deploy-strategy": "symlink",
+        "magento-root-dir": "./mage"
+    }
+
+}
+JSON;
+
+        $composerJson->fwrite($composerJsonContent);
+
+        $this->composer->install($this->projectDirectory, $composerJson);
+
+        $this->assertFileNotExists($this->testFilePath);
+    }
+
+    /**
+     * @group regression
+     */
+    public function testIncludeRootPackageIsFalse()
+    {
+        $this->prepareProject();
+
+
+        $composerJson = new  \SplTempFileObject();
+        $composerJsonContent = <<<JSON
+{
+    "name": "test/module",
+    "type": "magento-module",
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "http://packages.firegento.com"
+        },
+        {
+            "type": "artifact",
+            "url": "$this->artifactDirectory/"
+        }
+    ],
+    "require": {
+        "magento-hackathon/magento-composer-installer": "999.0.0"
+    },
+    "extra": {
+        "magento-deploy-strategy": "symlink",
+        "magento-root-dir": "./mage",
+        "include-root-package": false
+    }
+
+}
+JSON;
+
+        $composerJson->fwrite($composerJsonContent);
+
+        $this->composer->install($this->projectDirectory, $composerJson);
+
+        $this->assertFileNotExists($this->testFilePath);
+    }
+
+    /**
+     * @group regression
+     */
+    public function testIncludeRootPackageIsTrue()
+    {
+        $this->prepareProject();
+
+
+        $composerJson = new  \SplTempFileObject();
+        $composerJsonContent = <<<JSON
+{
+    "name": "test/module",
+    "type": "magento-module",
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "http://packages.firegento.com"
+        },
+        {
+            "type": "artifact",
+            "url": "$this->artifactDirectory/"
+        }
+    ],
+    "require": {
+        "magento-hackathon/magento-composer-installer": "999.0.0"
+    },
+    "extra": {
+        "magento-deploy-strategy": "symlink",
+        "magento-root-dir": "./mage",
+        "include-root-package": true
+    }
+
+}
+JSON;
+
+        $composerJson->fwrite($composerJsonContent);
+
+        $this->composer->install($this->projectDirectory, $composerJson);
+
+        $this->assertFileExists($this->testFilePath);
+    }
+}


### PR DESCRIPTION
As the title says, this commit enables the magento-composer-installer to include the root package in deployment. To make use of this feature, it has to be explicitly configured in a project's `composer.json` (for reference see the addition to the readme file).