### PR TITLE
Stop uninstaller following symlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
+- Fixed an issue where symlinks were follwed when removing a module, causing files in vendor to be removed
 
 ## [3.0.6] - 2015-10-21
 - Fix problems with magento connect packages referencing non existent files

--- a/src/MagentoHackathon/Composer/Magento/UnInstallStrategy/UnInstallStrategy.php
+++ b/src/MagentoHackathon/Composer/Magento/UnInstallStrategy/UnInstallStrategy.php
@@ -52,14 +52,19 @@ class UnInstallStrategy implements UnInstallStrategyInterface
             
             when the file is a symlink, but the target is already gone, file_exists returns false
             */
-            if (file_exists($file) xor is_link($file)) {
-                $this->fileSystem->unlink($file);
 
-                $parentDir = dirname($file);
-                while ($this->fileSystem->isDirEmpty($parentDir) && $parentDir !== $this->rootDir) {
-                    $this->fileSystem->removeDirectory($parentDir);
-                    $parentDir = dirname($parentDir);
-                }
+            if (is_link($file)) {
+                $this->fileSystem->unlink($file);
+            }
+            
+            if (file_exists($file)) {
+                $this->fileSystem->remove($file);
+            }
+
+            $parentDir = dirname($file);
+            while ($this->fileSystem->isDirEmpty($parentDir) && $parentDir !== $this->rootDir) {
+                $this->fileSystem->removeDirectory($parentDir);
+                $parentDir = dirname($parentDir);
             }
         }
     }

--- a/tests/MagentoHackathon/Composer/Magento/UninstallStrategy/UnInstallStrategyTest.php
+++ b/tests/MagentoHackathon/Composer/Magento/UninstallStrategy/UnInstallStrategyTest.php
@@ -85,6 +85,34 @@ class UnInstallStrategyTest extends \PHPUnit_Framework_TestCase
         $this->assertFileExists($rootDir . '/child4/secondlevelchild4/file5.txt');
     }
 
+    public function testUnInstallDoesNotFollowSymlinks()
+    {
+        $this->testDirectory    = sprintf('%s/%s', realpath(sys_get_temp_dir()), $this->getName());
+        $this->testDirectory    = str_replace('\\', '/', $this->testDirectory);
+        $rootDir                = $this->testDirectory . '/root';
+        mkdir($rootDir, 0777, true);
+
+        $strategy   = new UnInstallStrategy(new FileSystem, $rootDir);
+        
+        $symLinkDestination     = sprintf('%s/symlink_dest_dir', realpath(sys_get_temp_dir()));
+        $symLinkDestination     = str_replace('\\', '/', $symLinkDestination);
+        
+        mkdir($symLinkDestination, 0777, true);
+        mkdir($symLinkDestination . '/childfolder', 0777, true);
+        touch($symLinkDestination . '/childfile', 0777, true);
+        
+        symlink($symLinkDestination, $rootDir . '/link');
+
+        $strategy->unInstall(['/link']);
+
+        $this->assertFileExists($rootDir);
+        $this->assertFileNotExists($rootDir . '/link');
+
+        $this->assertFileExists($symLinkDestination);
+        $this->assertFileExists($symLinkDestination . '/childfolder');
+        $this->assertFileExists($symLinkDestination . '/childfile');
+    }
+
     public function tearDown()
     {
         $fs = new Filesystem;


### PR DESCRIPTION
When updating a module, the uninstaller was removing files from the vendor folder which meant when it tried to install the new version right after, the files were missing.

When uninstalling modules, we should not follow symlinks.