### PR TITLE
Added check to see if directory exists (for redeploy command)

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/UnInstallStrategy/UnInstallStrategy.php
+++ b/src/MagentoHackathon/Composer/Magento/UnInstallStrategy/UnInstallStrategy.php
@@ -49,14 +49,14 @@ class UnInstallStrategy implements UnInstallStrategyInterface
             example:
             - file got deployed by multiple modules(should only happen with copy force)
             - user did things
-            
+
             when the file is a symlink, but the target is already gone, file_exists returns false
             */
 
             if (is_link($file)) {
                 $this->fileSystem->unlink($file);
             }
-            
+
             if (file_exists($file)) {
                 $this->fileSystem->remove($file);
             }

--- a/src/MagentoHackathon/Composer/Magento/UnInstallStrategy/UnInstallStrategy.php
+++ b/src/MagentoHackathon/Composer/Magento/UnInstallStrategy/UnInstallStrategy.php
@@ -62,7 +62,11 @@ class UnInstallStrategy implements UnInstallStrategyInterface
             }
 
             $parentDir = dirname($file);
-            while ($this->fileSystem->isDirEmpty($parentDir) && $parentDir !== $this->rootDir) {
+            while (
+                is_dir($parentDir)
+                && $this->fileSystem->isDirEmpty($parentDir)
+                && $parentDir !== $this->rootDir
+            ) {
                 $this->fileSystem->removeDirectory($parentDir);
                 $parentDir = dirname($parentDir);
             }


### PR DESCRIPTION
I think there's a bug when you call `composer run-script post-update-cmd -vvv -- --redeploy`. Error message is: `[InvalidArgumentException] The [path] directory does not exist.` This seems to happen when the module is installed according to composer, but was not deployed to the Magento installation for whatever reason.

This usually happens when you add module to your composer.json, switch Git branches, add it there as well, and run Composer update. The Magento composer installer plugin won't deploy because nothing has changed in the vendor folder, unless you run redeploy (and then this bug occurs).

Usually what I do, is clear the vendor directory (or the module that's causing the issue), run composer update (and optionally run redeploy to make sure the if vendor directory is in sync with my Magento installation).

Anyhow, this PR should be an improvement to that. The only caveat is that it doesn't clean up the parent parent (and so on) directories any more if the top level directory doesn't exist, which shouldn't really matter as it wouldn't have done that anyway when this situation occurred.

Hope that made sense. Happy new year!