### PR TITLE
Resolve package.xml mappings edge case

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/Parser/PackageXmlParser.php
+++ b/src/MagentoHackathon/Composer/Magento/Parser/PackageXmlParser.php
@@ -66,7 +66,7 @@ class PackageXmlParser implements Parser
                             if (pathinfo($elementPath, PATHINFO_EXTENSION) == 'txt') {
                                 continue;
                             }
-                            $relativePath = $basePath . '/' . $elementPath;
+                            $relativePath = str_replace('//', '/', $basePath . '/' . $elementPath);
                             //remove the any trailing './' or '.' from the targets base-path.
                             if (strpos($relativePath, './') === 0) {
                                 $relativePath = substr($relativePath, 2);

--- a/tests/MagentoHackathon/Composer/Magento/Parser/PackageXmlParserTest.php
+++ b/tests/MagentoHackathon/Composer/Magento/Parser/PackageXmlParserTest.php
@@ -101,4 +101,18 @@ class PackageXmlParserTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($expected, $parser->getMappings());
     }
+
+    public function testNestedDirMappingsDontContainDoubleSlashes()
+    {
+        $parser = new PackageXmlParser(vfsStream::url('root/PackageXmlNestedDirs.xml'));
+
+        $expected = array (
+            array(
+                'app/design/frontend/base/default/template/module/folder/view.phtml',
+                'app/design/frontend/base/default/template/module/folder/view.phtml',
+            ),
+        );
+
+        $this->assertSame($expected, $parser->getMappings());
+    }
 }

--- a/tests/res/fixtures/PackageXmlNestedDirs.xml
+++ b/tests/res/fixtures/PackageXmlNestedDirs.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<package>
+  <name>Some_Module</name>
+  <version>1</version>
+  <stability>stable</stability>
+  <license uri="http://opensource.org/licenses/OSL-3.0">Open Software License (OSL-3.0)</license>
+  <channel>community</channel>
+  <extends/>
+  <summary>Some Module</summary>
+  <description>Some Module</description>
+  <notes>Notes</notes>
+  <authors><author><name>Aydin</name><user>aydin</user><email>aydin@hotmail.co.uk</email></author></authors>
+  <date>2014-10-28</date>
+  <time>13:44:36</time>
+    <contents>
+        <target name="magedesign">
+            <dir name="frontend">
+                <dir name="base">
+                    <dir name="default">
+                        <dir name="template">
+                            <dir name="module">
+                                <dir> <!-- THIS IS GENERATED BUT WILL CAUSE // IN MAPPINGS -->
+                                    <dir name="folder">
+                                        <file name="view.phtml" hash="7243f533d0357685aa5cf8c115b148a1" />
+                                    </dir>
+                                </dir>
+                            </dir>
+
+                        </dir>
+                    </dir>
+                </dir>
+            </dir>
+        </target>
+    </contents>
+    <compatible />
+    <dependencies>
+        <required>
+            <php>
+                <min>5.2.0</min>
+                <max>8.0.0</max>
+            </php>
+        </required>
+    </dependencies>
+</package>


### PR DESCRIPTION
* Replace double slashes in mappings

Sometimes dirs are mapped into empty dir tags
causing double slashes in the mapping.