### PR TITLE
Use HTTPS for repository urls

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/Plugin.php
+++ b/src/MagentoHackathon/Composer/Magento/Plugin.php
@@ -266,7 +266,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         $message2 = "<comment>add it with:</comment> composer.phar config -g repositories.%s composer %s";
         if (!$foundFiregento) {
             $this->io->write(sprintf($message1, 'packages.firegento.com'));
-            $this->io->write(sprintf($message2, 'firegento', 'http://packages.firegento.com'));
+            $this->io->write(sprintf($message2, 'firegento', 'https://packages.firegento.com'));
         }
         if (!$foundMagento) {
             $this->io->write(sprintf($message1, 'packages.magento.com'));

--- a/src/MagentoHackathon/Composer/Magento/Plugin.php
+++ b/src/MagentoHackathon/Composer/Magento/Plugin.php
@@ -270,7 +270,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         }
         if (!$foundMagento) {
             $this->io->write(sprintf($message1, 'packages.magento.com'));
-            $this->io->write(sprintf($message2, 'magento', 'https?://packages.magento.com'));
+            $this->io->write(sprintf($message2, 'magento', 'https://packages.magento.com'));
         }
 
     }

--- a/tests/FullStackTest/home/composer.json
+++ b/tests/FullStackTest/home/composer.json
@@ -2,7 +2,7 @@
     "repositories": [
         {
             "type": "composer",
-            "url": "http://packages.firegento.com"
+            "url": "https://packages.firegento.com"
         },
         {
             "type": "artifact",

--- a/tests/FullStackTest/magento-modules/composer_1.json
+++ b/tests/FullStackTest/magento-modules/composer_1.json
@@ -26,7 +26,7 @@
         },
 		{
 			"type": "composer",
-			"url": "http://packages.firegento.com"
+			"url": "https://packages.firegento.com"
 		}
 	],
 	"extra":{

--- a/tests/FullStackTest/magento-modules/composer_1_copy.json
+++ b/tests/FullStackTest/magento-modules/composer_1_copy.json
@@ -27,7 +27,7 @@
         },
 		{
 			"type": "composer",
-			"url": "http://packages.firegento.com"
+			"url": "https://packages.firegento.com"
 		}
 	],
 	"extra":{

--- a/tests/FullStackTest/magento-modules/composer_1_copy_force.json
+++ b/tests/FullStackTest/magento-modules/composer_1_copy_force.json
@@ -30,7 +30,7 @@
         },
 		{
 			"type": "composer",
-			"url": "http://packages.firegento.com"
+			"url": "https://packages.firegento.com"
 		}
 	],
 	"extra":{

--- a/tests/FullStackTest/magento-modules/composer_2.json
+++ b/tests/FullStackTest/magento-modules/composer_2.json
@@ -12,7 +12,7 @@
         },
 		{
 			"type": "composer",
-			"url": "http://packages.firegento.com"
+			"url": "https://packages.firegento.com"
 		}
 	],
 	"extra":{

--- a/tests/FullStackTest/magento-modules/composer_2_copy.json
+++ b/tests/FullStackTest/magento-modules/composer_2_copy.json
@@ -12,7 +12,7 @@
         },
 		{
 			"type": "composer",
-			"url": "http://packages.firegento.com"
+			"url": "https://packages.firegento.com"
 		}
 	],
 	"extra":{

--- a/tests/FullStackTest/magento-modules/composer_2_copy_force.json
+++ b/tests/FullStackTest/magento-modules/composer_2_copy_force.json
@@ -12,7 +12,7 @@
         },
 		{
 			"type": "composer",
-			"url": "http://packages.firegento.com"
+			"url": "https://packages.firegento.com"
 		}
 	],
 	"extra":{

--- a/tests/FullStackTest/magento/composer.json
+++ b/tests/FullStackTest/magento/composer.json
@@ -2,7 +2,7 @@
     "repositories": [
         {
             "type": "composer",
-            "url": "http://packages.firegento.com"
+            "url": "https://packages.firegento.com"
         },
         {
             "type": "artifact",

--- a/tests/MagentoHackathon/Composer/FullStack/Regression/Issue139Test.php
+++ b/tests/MagentoHackathon/Composer/FullStack/Regression/Issue139Test.php
@@ -34,7 +34,7 @@ class Issue139Test extends ComposerTestFramework\PHPUnit\FullStackTestCase
                 ],
                 [
                     'type' => 'composer',
-                    'url' => 'http://packages.firegento.com'
+                    'url' => 'https://packages.firegento.com'
                 ],
             ],
             'require' => [

--- a/tests/MagentoHackathon/Composer/FullStack/Regression/IssueC039Test.php
+++ b/tests/MagentoHackathon/Composer/FullStack/Regression/IssueC039Test.php
@@ -32,7 +32,7 @@ class IssueC039Test extends ComposerTestFramework\PHPUnit\FullStackTestCase
                 ],
                 [
                     'type' => 'composer',
-                    'url' => 'http://packages.firegento.com'
+                    'url' => 'https://packages.firegento.com'
                 ],
 
             ],
@@ -61,7 +61,7 @@ class IssueC039Test extends ComposerTestFramework\PHPUnit\FullStackTestCase
                 ],
                 [
                     'type' => 'composer',
-                    'url' => 'http://packages.firegento.com'
+                    'url' => 'https://packages.firegento.com'
                 ],
             ],
             'require' => [


### PR DESCRIPTION
Since the [Composer beta1 release](https://github.com/composer/composer/releases/tag/1.0.0-beta1) of 03-03-2016 the use of unsecure url's is prohibited by default. See also the [documentation](https://getcomposer.org/doc/06-config.md#secure-http) of the `secure-http` config option.

This PR changes all uses of HTTP in this repository to HTTPS.

Note that this PR fixes a number of tests in the test suite, but not all: downloads of `connect20` packages still use HTTP; this should be fixed somewhere else.