### PR TITLE
Remove version constraint from composer require statement in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ further information can be found on [wikibooks](http://en.wikibooks.org/wiki/Ope
 as this is a composer plugin, you should only use this both commands to update the installer
 
 ``` 
-composer require --no-update  magento-hackathon/magento-composer-installer=3.0.*
+composer require --no-update  magento-hackathon/magento-composer-installer
 composer update --no-plugins --no-scripts magento-hackathon/magento-composer-installer
 ```
 


### PR DESCRIPTION
Instead of using the asterisk (*), it is better to use the caret operator (^); see slides 50 to 68 of the [Composer the Right Way presentation from PHPBenelux16](http://www.slideshare.net/rdohms/composer-the-right-way-phpbnl16) by Rafael Dohms.

It is even better to not specify any version constraint, so Composer can determine the constraint automatically (using the caret operator).