### PR TITLE
Stop following symlinks on deploy

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/ModuleManager.php
+++ b/src/MagentoHackathon/Composer/Magento/ModuleManager.php
@@ -208,7 +208,10 @@ class ModuleManager
             $path = sprintf("%s/%s", $path, $targetDir);
         }
 
-        $path = realpath($path);
+        if (!is_link($path)) {
+            $path = realpath($path);
+        }
+
         return $path;
     }
 


### PR DESCRIPTION
This should fix #70 

When local repo is used, this links the magento folders to vendor, instead of the local repo. This makes sure that, when a package is installed, the symlink isn't working anymore.

Does need review if it actually solves all problems with local repos.

(Not sure if it should actually remove all dead symlinks, or that this isn't needed now)