### PR TITLE
Remove support for PHP 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         }
     ],
     "require":{
-        "php": ">=5.4",
+        "php": ">=5.5",
         "eloquent/composer-config-reader": "2.*",
         "symfony/console": "~2.5",
         "composer-plugin-api": "~1.0"


### PR DESCRIPTION
composer.json did wrongfully show PHP 5.4 as a supported version.

But PHP 5.4 is unsupported.

This is an easy fix by raising the version constraint from 5.4 to 5.5.

See https://github.com/Cotya/magento-composer-installer/issues/43#issuecomment-193961823

Ref: https://github.com/magento-hackathon/magento-composer-installer/issues/195 , #43