### PR TITLE
fixing bug with 1.1 composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "php": ">=5.5",
         "eloquent/composer-config-reader": "2.*",
         "symfony/console": "^2.5|^3.0",
-        "composer-plugin-api": "~1.0"
+        "composer-plugin-api": "^1.0"
     },
     "require-dev":{
         "phpunit/phpunit":"~4.3",


### PR DESCRIPTION
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - magento-hackathon/magento-composer-installer 2.0.0 requires composer-plugin-api 1.0.0 -> no matching package found.
    - magento-hackathon/magento-composer-installer 2.0.0 requires composer-plugin-api 1.0.0 -> no matching package found.
    - magento-hackathon/magento-composer-installer 2.0.0 requires composer-plugin-api 1.0.0 -> no matching package found.
    - Installation request for magento-hackathon/magento-composer-installer 2.0.0 -> satisfiable by magento-hackathon/magento-composer-installer[2.0.0].