### PR TITLE
Fix Mage.php match for systems with open_basedir

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/Patcher/Bootstrap.php
+++ b/src/MagentoHackathon/Composer/Magento/Patcher/Bootstrap.php
@@ -199,8 +199,8 @@ class Bootstrap
 
         return <<<PATCH
 /** $patchMark **/
-if (file_exists(\$autoloaderPath = BP . DS . '../{$autoloadPhp}') ||
-    file_exists(\$autoloaderPath = BP . DS . '{$autoloadPhp}')
+if (file_exists(\$autoloaderPath = BP . DS . '{$autoloadPhp}') ||
+    file_exists(\$autoloaderPath = BP . DS . '../{$autoloadPhp}')
 ) {
     require \$autoloaderPath;
 }


### PR DESCRIPTION
On system, where is open basedir setup for root web directory as most top, previous setup fails in fatal error.

This fix switched the order of file check and in case file match, second part of condition won`t be run. This fix error in these systems.

Tested many times.