### PR TITLE
add workaround to handle windows symlinks

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/Deploystrategy/Symlink.php
+++ b/src/MagentoHackathon/Composer/Magento/Deploystrategy/Symlink.php
@@ -127,11 +127,22 @@ class Symlink extends DeploystrategyAbstract
     protected function symlink($relSourcePath, $destPath, $absSourcePath)
     {
         $sourcePath = $relSourcePath;
-        // make symlinks always absolute on windows because of #142
+        // use console native windows tool to create relative windows symlinks
         if (strtoupper(substr(PHP_OS, 0, 3)) == 'WIN') {
-            $sourcePath = str_replace('/', '\\', $absSourcePath);
+            $sourcePath = str_replace('/', '\\', $sourcePath);
+            $symlinkDir = dirname($destPath);
+            $currentDir = getcwd();
+            chdir($symlinkDir);
+
+            $flag = is_dir($symlinkDir . '\\' . $sourcePath) ? '/D ' : '';
+            $pathInfo = pathinfo($destPath);
+            $res = exec('mklink ' . $flag . $pathInfo['basename'] .' '. $sourcePath);
+
+            chdir($currentDir);
+            return $res;
+        } else {
+            return symlink($sourcePath, $destPath);
         }
-        return symlink($sourcePath, $destPath);
     }
 
     /**

--- a/src/MagentoHackathon/Composer/Magento/UnInstallStrategy/UnInstallStrategy.php
+++ b/src/MagentoHackathon/Composer/Magento/UnInstallStrategy/UnInstallStrategy.php
@@ -54,7 +54,11 @@ class UnInstallStrategy implements UnInstallStrategyInterface
             */
 
             if (is_link($file)) {
-                $this->fileSystem->unlink($file);
+                if (strtoupper(substr(PHP_OS, 0, 3)) == 'WIN') {
+                    @unlink($file) || @rmdir($file);
+                } else {
+                    $this->fileSystem->unlink($file);
+                }
             }
 
             if (file_exists($file)) {


### PR DESCRIPTION
there is problem with absolute links when using virtual machine with shared ntfs folders. 
absolute paths in ntfs symlinks does not apearing on vritual machine linux os. 
php symlinks supports only absolute paths for windows environment, but there is still way to use relative paths for symlinks. I implemented a litle workaround using native mklink command, i tested and it works great. 

also, there is problem duriong uninstallation. happens on windows while deleting symlinks with no targets. is_dir returns false for symlinks which linkling to unexisting folder. in this case i think it is fine if will try to remove it by using rmdir even if is_dir returned false.

do you think it doable? 
