### PR TITLE
Add absolute symlink strategy 

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/Deploystrategy/AbsoluteSymlink.php
+++ b/src/MagentoHackathon/Composer/Magento/Deploystrategy/AbsoluteSymlink.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Composer Magento Installer
+ */
+
+namespace MagentoHackathon\Composer\Magento\Deploystrategy;
+
+/**
+ * Absolute Symlink deploy strategy
+ */
+class AbsoluteSymlink extends Symlink
+{
+    /**
+     * @inheritdoc
+     */
+    protected function symlink($relSourcePath, $destPath, $absSourcePath)
+    {
+        // make symlinks always absolute on windows because of #142
+        if (strtoupper(substr(PHP_OS, 0, 3)) == 'WIN') {
+            $absSourcePath = str_replace('/', '\\', $absSourcePath);
+        }
+        return symlink($absSourcePath, $destPath);
+    }
+}

--- a/src/MagentoHackathon/Composer/Magento/Factory/DeploystrategyFactory.php
+++ b/src/MagentoHackathon/Composer/Magento/Factory/DeploystrategyFactory.php
@@ -22,10 +22,11 @@ class DeploystrategyFactory
      * @var array
      */
     protected static $strategies = array(
-        'copy'      => '\MagentoHackathon\Composer\Magento\Deploystrategy\Copy',
-        'symlink'   => '\MagentoHackathon\Composer\Magento\Deploystrategy\Symlink',
-        'link'      => '\MagentoHackathon\Composer\Magento\Deploystrategy\Link',
-        'none'      => '\MagentoHackathon\Composer\Magento\Deploystrategy\None',
+        'copy'            => '\MagentoHackathon\Composer\Magento\Deploystrategy\Copy',
+        'symlink'         => '\MagentoHackathon\Composer\Magento\Deploystrategy\Symlink',
+        'absoluteSymlink' => '\MagentoHackathon\Composer\Magento\Deploystrategy\AbsoluteSymlink',
+        'link'            => '\MagentoHackathon\Composer\Magento\Deploystrategy\Link',
+        'none'            => '\MagentoHackathon\Composer\Magento\Deploystrategy\None',
     );
 
     /**


### PR DESCRIPTION
because the relative symlink strategy fails under certain circumstances.