### PR TITLE
Changed http to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This project only covers the custom installer for composer. If you have problems
 need to install magento connect modules or similar, you need to look for [packages.firegento.com](http://packages.firegento.com/)
 which you probably should add as composer repository (globally)
 
-```composer config -g repositories.firegento composer http://packages.firegento.com```
+```composer config -g repositories.firegento composer https://packages.firegento.com```
 
 ### supported PHP Versions
 


### PR DESCRIPTION
I changed the README.md to use https by default. If you don't do this, Composer will refuse to install if you don't include the `secure-http: false` in your composer.json.