### PR TITLE
fix: avoid crashing on update if the rule does not contain a job

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/Plugin.php
+++ b/src/MagentoHackathon/Composer/Magento/Plugin.php
@@ -264,7 +264,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         $rule = $event->getOperation()->getReason();
         if ($rule instanceof Rule) {
             if ($event->getOperation()->getJobType() === 'update') {
-                if ($rule->getJob()['packageName'] === 'magento-hackathon/magento-composer-installer') {
+                if ($rule->getJob() && $rule->getJob()['packageName'] === 'magento-hackathon/magento-composer-installer') {
                     throw new \Exception(
                         'Dont update the "magento-hackathon/magento-composer-installer" with active plugins.' . PHP_EOL .
                         'Consult the documentation on how to update the Installer' . PHP_EOL .


### PR DESCRIPTION
In later PHP-versions attempts to access array offsets on nulls result in errors, which prevents any `composer update` commands from running, this PR fixes that.