### PR TITLE
Compatibility with newer versions of Symfony

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/Plugin.php
+++ b/src/MagentoHackathon/Composer/Magento/Plugin.php
@@ -369,7 +369,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
 
             $params = $this->getTheseerAutoloadParams($libraryPath, $autoloadDirectories);
 
-            $process = new Process($executable . $params);
+            $process = new Process([$executable, $params]);
             $process->run();
         }
     }


### PR DESCRIPTION
Newer versions of Symfony Process requires an array as an constructor argument. 
Array was supported already in previous versions (since ~v4).