### PR TITLE
fix deploy strategy change from symlink to copy

### DIFF
--- a/src/MagentoHackathon/Composer/Magento/Deploystrategy/Copy.php
+++ b/src/MagentoHackathon/Composer/Magento/Deploystrategy/Copy.php
@@ -28,6 +28,10 @@ class Copy extends DeploystrategyAbstract
         $sourcePath = $this->getSourceDir() . '/' . $this->removeTrailingSlash($source);
         $destPath = $this->getDestDir() . '/' . $this->removeTrailingSlash($dest);
 
+        //remove symlink to avoid unlink files from vendor directory
+        if (is_link($destPath)) {
+            unlink($destPath);
+        }
 
         // Create all directories up to one below the target if they don't exist
         $destDir = dirname($destPath);


### PR DESCRIPTION
This fix https://github.com/Cotya/magento-composer-installer/issues/23

How to reproduce?

1. Create composer.json `{
    "require": {
        "aydin-hassan/magento-core-composer-installer": "2.1.0",
        "openmage/magento-lts": "v19.4.15",
        "magento-hackathon/magento-composer-installer": "4.0.2",
        "aoepeople/aoe_scheduler": "1.5.2",
        "ext-zlib": "*"
    },
    "extra": {
        "magento-core-package-type": "magento-source",
        "magento-root-dir": "htdocs",
        "magento-force": true,
        "magento-deploystrategy": "symlink",
        "magento-deploystrategy-dev": "symlink"
    },
    "config": {
        "allow-plugins": {
            "aydin-hassan/magento-core-composer-installer": true,
            "magento-hackathon/magento-composer-installer": true
        }
    }
}`
2. run `composer install`
3. change magento-deploystrategy to copy (composer.json)
4. remove vendor dir
5. run `composer install`
 
